### PR TITLE
フラッシュメッセージ

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,6 +7,10 @@ class ApplicationController < ActionController::Base
   before_action :require_login
   # require_login は、gem 'sorcery' が提供するメソッドの一つで、ユーザーがログインしているかどうかを判定
   # ログインしていない場合は、not_authenticated メソッドで指定されたパスにリダイレクト
+  add_flash_types :success, :danger
+  # フラッシュメッセージのタイプを追加するメソッド
+  # デフォルトでは、notice と alert の二種類のキーしか用意されていないので、
+  # 今回は、成功・失敗した際のメッセージに適用されるキーを追加するために、success と danger という2つのキーを追加
   private
 
   # not_authenticated メソッドも gem 'sorcery' が提供するもので、ログインしていない場合に指定されたパスにリダイレクト

--- a/app/controllers/diagnoses_controller.rb
+++ b/app/controllers/diagnoses_controller.rb
@@ -40,20 +40,16 @@ class DiagnosesController < ApplicationController
   def create
     @diagnosis = Diagnosis.new(diagnosis_params)
 
-    # すべての質問が回答されているかチェック
+    # 部分的に質問が未選択の場合 にもフラッシュメッセージを表示
     if diagnosis_params[:question1].blank? || diagnosis_params[:question2].blank? || diagnosis_params[:question3].blank?
-      flash[:alert] = "選択されていない回答があります"
-      render :new
+      flash.now[:danger] = t("users.create.diagnoses_null")
+      render :new, status: :unprocessable_entity
     else
       # 各質問の回答を連結して一つの文字列にする
       @diagnosis.question = "#{diagnosis_params[:question1]}#{diagnosis_params[:question2]}#{diagnosis_params[:question3]}"
 
       if @diagnosis.save
-        flash[:notice] = "診断が完了しました"
-        redirect_to diagnosis_path(@diagnosis)
-      else
-        flash[:alert] = "診断に失敗しました"
-        render :new
+        redirect_to diagnosis_path(@diagnosis), success: t("users.create.diagnoses_success")
       end
     end
   end

--- a/app/controllers/user_sessions_controller.rb
+++ b/app/controllers/user_sessions_controller.rb
@@ -11,14 +11,19 @@ class UserSessionsController < ApplicationController
       # ユーザーの認証を行い、指定されたメールアドレスとパスワードがデータベース内のユーザー情報と一致するかどうかを確認
       # 認証が成功した場合、該当するユーザーはセッションに値をセットされてログイン状態になる
       if @user
-        redirect_to root_path
+        # success: t('user_sessions.create.success')を追記し、ログインに成功しましたとフラッシュメッセージを放つ
+        redirect_to root_path, success: t("user_sessions.create.success")
       # redirect_toについて
       # redirect_to メソッドは、指定されたURLへユーザーをリダイレクトする
       # リダイレクトはサーバーがクライアントに別のURLへの移動を指示するプロセス
       # このメソッドは通常、アクション完了後にユーザーを適切なページへ導くために使用され、セッション情報の更新や重複データ送信の防止に役立つ
       # 例えば、ログインやログアウト後のリダイレクトはユーザーの認証状態を更新し、その結果を新しいリクエストに即座に反映させる
       else
-        render :new
+        # render :new
+        # ↓
+        # success: t('user_sessions.create.success')を追記し、ログインに失敗しましたとフラッシュメッセージを放つ
+        flash.now[:danger] = t("users.create.failure")
+        render :new, status: :unprocessable_entity
         # renderについて
         # render メソッドは指定されたビューテンプレートの内容をクライアントに返し、現在のウェブページを更新する
         # この操作は新しいページへの移動を伴わずに行われ、サーバーは直接HTMLをレスポンスとして送信する
@@ -28,7 +33,8 @@ class UserSessionsController < ApplicationController
 
     def destroy
       logout
-      redirect_to root_path, status: :see_other
+      # ログアウトしましたとフラッシュメッセージを放つ
+      redirect_to root_path, status: :see_other, danger: t("user_sessions.destroy.success")
       # redirect_toについて
       # redirect_to メソッドは、指定されたURLへユーザーをリダイレクトする
       # リダイレクトはサーバーがクライアントに別のURLへの移動を指示するプロセス

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -19,10 +19,17 @@ class UsersController < ApplicationController
 
     def create
       @user = User.new(user_params)
-      if @user.save
-        redirect_to root_path
-      else
-        render :new
+      if @user.save # step5修正
+        # redirect_to root_path
+        # ↓
+        # ユーザー登録保存出来たら、ユーザー登録が完了しましたと表示する
+        redirect_to root_path, success: t("users.create.success")
+      else # step5追加、修正
+        # render :new
+        # ↓
+        # ユーザー登録保存に失敗したら、ユーザー登録が失敗しましたと表示する
+        flash.now[:danger] = t("users.create.failure")
+        render :new, status: :unprocessable_entity
       end
     end
 

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -17,6 +17,7 @@
     <% else %>
       <%= render 'shared/before_login_header' %>
     <% end %>
+    <%= render 'shared/flash_message' %>
     <%= yield %>
     <%= render 'shared/footer' %>
   </body>

--- a/app/views/shared/_flash_message.html.erb
+++ b/app/views/shared/_flash_message.html.erb
@@ -1,0 +1,7 @@
+<% flash.each do |message_type, message| %>
+    <div class="alert alert-<%= message_type %> alert-dismissible fade show" role="alert">
+      <%= message %>
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
+    </div>
+  <% end %>
+  

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -13,6 +13,17 @@ ja:
       login: ログイン
       to_register_page: 初めての方はこちら
       password_forget: パスワードをお忘れの方はこちら
+    create:
+      success: ログインしました
+      failure: ログインに失敗しました
+    destroy:
+      success: ログアウトしました
+  users:
+    create:
+      success: ユーザー登録が完了しました
+      failure: ユーザー登録に失敗しました
+      diagnoses_success: 診断が完了しました
+      diagnoses_null: 選択されていない回答があります
   header:
     login: ログイン
     logout: ログアウト


### PR DESCRIPTION
# **■app/controllers/application_controller.rb に add_flash_types を記述する**

### **success・danger を flash_types に追加する**

```ruby
class ApplicationController < ActionController::Base
# 省略
add_flash_types :success, :danger
  # フラッシュメッセージのタイプを追加するメソッド
  # デフォルトでは、notice と alert の二種類のキーしか用意されていないので、
  # 今回は、成功・失敗した際のメッセージに適用されるキーを追加するために、success と danger という2つのキーを追加
  private
# 省略
end
```

# **■新規ユーザー登録時（成功・失敗）にフラッシュメッセージを表示する**

### **成功**

### **app/controllers/users_controller.rb を編集する**

```ruby
class UsersController < ApplicationController
# 省略
def create
      @user = User.new(user_params)
      if @user.save # step5修正
        # redirect_to root_path
        # ↓
        redirect_to root_path, success: t('users.create.success')
      else # step5追加、修正
        # render :new
        # ↓
        flash.now[:danger] = t('users.create.failure')
        render :new, status: :unprocessable_entity
      end
    end
 # 省略
 end
```

# **■共通化する**

### **部分テンプレートを用意する**

app/views/shared/_flash_message.html.erb を生成して以下の記述を行う

```html
<% flash.each do |message_type, message| %>
    <div class="alert alert-<%= message_type %> alert-dismissible fade show" role="alert">
      <%= message %>
      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
    </div>
  <% end %>
```

●フラッシュメッセージのスタイル

フラッシュメッセージが緑色になるのは、Bootstrapのクラスを利用していることが関係している

alert クラスと、alert-success クラスを使用されると対象のdivの箇所が緑色になり、alert-danger クラスを使用されると対象のdivの箇所が赤色になる

```html
<button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
```

閉じるボタン付きのフラッシュメッセージを実装するには、上記のように`alert-dismissible` クラスを追加し、閉じるボタンのHTMLを挿入する

- **`alert-dismissible` クラス**: これにより、アラートが閉じられるようになる
- **`fade` と `show` クラス**: `fade` クラスはアラートが閉じられる際にアニメーション効果を追加し、`show` クラスはアラートを表示状態にするために必要
- **閉じるボタン**: `<button>` タグに `btn-close` クラスを追加し、`data-bs-dismiss="alert"` 属性を設定することで、クリックでアラートを閉じることができる

# **■i18nによる日本語化を行う**

```yaml
ja:
          create:
      success: ログインしました
      failure: ログインに失敗しました
    destroy:
      success: ログアウトしました
  users:
    create:
      success: ユーザー登録が完了しました
      failure: ユーザー登録に失敗しました
      diagnoses_success: 診断が完了しました
      diagnoses_null: 選択されていない回答があります

```

app/controllers/user_sessions_controller.rb

```ruby
class UserSessionsController < ApplicationController
    skip_before_action :require_login, only: %i[new create]
    # 省略
    def create
      # 省略
      if @user
      # success: t('user_sessions.create.success')を追記し、ログインに成功しましたとフラッシュメッセージを放つ
        redirect_to root_path, success: t('user_sessions.create.success')
      else
        # render :new
        # ↓
        # success: t('user_sessions.create.success')を追記し、ログインに失敗しましたとフラッシュメッセージを放つ
        flash.now[:danger] = t('users.create.failure')
        render :new, status: :unprocessable_entity
        # renderについて
        # render メソッドは指定されたビューテンプレートの内容をクライアントに返し、現在のウェブページを更新する
        # この操作は新しいページへの移動を伴わずに行われ、サーバーは直接HTMLをレスポンスとして送信する
        # ユーザーの入力エラーがあった場合に特に有効で、redirect_toが新しいHTTPリクエストを生成しフォームデータを失うのに対し、renderは現在のHTTPリクエスト内でビューを直接表示し、入力データを保持する
      end
    end

    def destroy
      logout
      #ログアウトしましたとフラッシュメッセージを放つ
      redirect_to root_path, status: :see_other, danger: t('user_sessions.destroy.success')
    end
end
```

app/controllers/user_controller.rb

```ruby
class UsersController < ApplicationController
# 省略
def create
      @user = User.new(user_params)
      if @user.save # step5修正
        # redirect_to root_path
        # ↓
        # ユーザー登録保存出来たら、ユーザー登録が完了しましたと表示する
        redirect_to root_path, success: t('users.create.success')
      else # step5追加、修正
        # render :new
        # ↓
        # ユーザー登録保存に失敗したら、ユーザー登録が失敗しましたと表示する
        flash.now[:danger] = t('users.create.failure')
        render :new, status: :unprocessable_entity
      end
    end
# 省略
end
```

app/controllers/diagnosis_controller.rb

```ruby
class DiagnosesController < ApplicationController
　# 省略
def create
    @diagnosis = Diagnosis.new(diagnosis_params)

    # 部分的に質問が未選択の場合 にもフラッシュメッセージを表示
    if diagnosis_params[:question1].blank? || diagnosis_params[:question2].blank? || diagnosis_params[:question3].blank?
      flash.now[:danger] = t('users.create.diagnoses_null')
      render :new, status: :unprocessable_entity
    else
      # 各質問の回答を連結して一つの文字列にする
      @diagnosis.question = "#{diagnosis_params[:question1]}#{diagnosis_params[:question2]}#{diagnosis_params[:question3]}"

      if @diagnosis.save
        redirect_to diagnosis_path(@diagnosis), success: t('users.create.diagnoses_success')
      end
    end
  end
 # 省略
end
```