### PR TITLE
ジョージアってどんな国？が消えてたので、再作成

### DIFF
--- a/app/views/static_pages/georgia.html.erb
+++ b/app/views/static_pages/georgia.html.erb
@@ -1,0 +1,23 @@
+<div class="top-wrapper">
+  <div class="georgia-inner-text">
+    <h1>ジョージアってどんな国？</h1>
+  </div>
+  <br>
+    <div class="georgia-deta">
+    <p>1. 面積<br>6万9,700平方キロメートル（日本の約5分の1）</p>
+    <p>2. 人口<br>370万人（2023年：国連人口基金）</p>
+    <p>3. 首都<br>トビリシ</p>
+    <p>4. 民族<br>ジョージア系（86.8％）、アゼルバイジャン系（6.2％）、アルメニア系（4.5％）、ロシア系（0.7％）、オセチア系（0.4％）</p>
+    <p>5. 言語<br>公用語はジョージア語（コーカサス諸語に属する）</p>
+    <p>6. 宗教<br>主としてキリスト教（ジョージア正教）</p>
+    <p>7. その他<br>コーカサス山脈の南側、黒海の東岸に位置し、アジアとヨーロッパをつなぐ交通の要衝<br>
+      ワインの原料となるブドウの醸造文化は8000年以上の歴史があり、世界最古ともいわれている。現在もワイン生産が盛ん</p>
+    <p>参考資料:<br>
+      <a href="https://www.mofa.go.jp/mofaj/area/georgia/index.html" target="_blank">外務省：ジョージア</a><br>
+      <a href="https://www.mofa.go.jp/mofaj/area/georgia/data.html" target="_blank">外務省：ジョージアのデータ</a></p>
+    </div>
+    <!-- 画像 -->
+    <img src="/assets/Georgia.gif" alt="ジョージアの旗" class="georgia-flag">
+    <img src="/assets/Image02.png" alt="普通のブドウ" class="image02">
+    </div>
+</div>


### PR DESCRIPTION
ジョージアってどんな国？のHTMLを誤って消していたので、再作成
```HTML
<div class="top-wrapper">
  <div class="georgia-inner-text">
    <h1>ジョージアってどんな国？</h1>
  </div>
  <br>
    <div class="georgia-deta">
    <p>1. 面積<br>6万9,700平方キロメートル（日本の約5分の1）</p>
    <p>2. 人口<br>370万人（2023年：国連人口基金）</p>
    <p>3. 首都<br>トビリシ</p>
    <p>4. 民族<br>ジョージア系（86.8％）、アゼルバイジャン系（6.2％）、アルメニア系（4.5％）、ロシア系（0.7％）、オセチア系（0.4％）</p>
    <p>5. 言語<br>公用語はジョージア語（コーカサス諸語に属する）</p>
    <p>6. 宗教<br>主としてキリスト教（ジョージア正教）</p>
    <p>7. その他<br>コーカサス山脈の南側、黒海の東岸に位置し、アジアとヨーロッパをつなぐ交通の要衝<br>
      ワインの原料となるブドウの醸造文化は8000年以上の歴史があり、世界最古ともいわれている。現在もワイン生産が盛ん</p>
    <p>参考資料:<br>
      <a href="https://www.mofa.go.jp/mofaj/area/georgia/index.html" target="_blank">外務省：ジョージア</a><br>
      <a href="https://www.mofa.go.jp/mofaj/area/georgia/data.html" target="_blank">外務省：ジョージアのデータ</a></p>
    </div>
    <!-- 画像 -->
    <img src="/assets/Georgia.gif" alt="ジョージアの旗" class="georgia-flag">
    <img src="/assets/Image02.png" alt="普通のブドウ" class="image02">
    </div>
</div>
```