### PR TITLE
コメント機能のAjax化

### DIFF
--- a/app/controllers/comments_controller.rb
+++ b/app/controllers/comments_controller.rb
@@ -4,20 +4,27 @@ class CommentsController < ApplicationController
       # RailsのActiveRecordが提供するメソッドで、渡されたIDを元にデータベースから特定のレコードを取得する
       # 例えば、User.find(255)とすると、IDが255のUsersテーブルのレコードを取得する。
       # 存在しないIDを渡すと、ActiveRecord::RecordNotFound例外が発生する
-      @post = Post.find(params[:post_id])
+      # @post = Post.find(params[:post_id])
       # createアクション内で params[:post_id] を使うことでURLの掲示板のIDパラメータ(65535)を取得できる
       # params はハッシュ形式でデータを保持するため、キーを指定して対応する値を取得することができる
-      @comment = @post.comments.build(comment_params)
-      @comment.user = current_user
+      # @comment = @post.comments.build(comment_params)
+      # @comment.user = current_user
 
-      if @comment.save
-        # url オプションを用いることで、フォームの送信先URLを明示的に指定
-        redirect_to post_path(@post), success: t("defaults.flash_message.created", item: Comment.model_name.human)
-      else
-        @comments = @post.comments.includes(:user).order(created_at: :desc)
-        flash.now[:danger] = t("defaults.flash_message.not_created", item: Comment.model_name.human)
-        render "posts/show", status: :unprocessable_entity
-      end
+      # if @comment.save
+      # url オプションを用いることで、フォームの送信先URLを明示的に指定
+      # redirect_to post_path(@post), success: t("defaults.flash_message.created", item: Comment.model_name.human)
+      # else
+      # @comments = @post.comments.includes(:user).order(created_at: :desc)
+      # flash.now[:danger] = t("defaults.flash_message.not_created", item: Comment.model_name.human)
+      # render "posts/show", status: :unprocessable_entity
+      # end
+      @comment = current_user.comments.build(comment_params)
+      @comment.save
+    end
+
+    def destroy
+      @comment = current_user.comments.find(params[:id])
+      @comment.destroy!
     end
 
     private

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,6 +17,9 @@ class User < ApplicationRecord
   has_many :favorites, dependent: :destroy
   # dependent: :destroyを記述することによって、destroy 時に関連づけられたモデルに対して destroy が実行されるようになる
   # 今回の場合では、掲示板が削除されたときに、そのユーザーに関連するFavoriteレコードも一緒に削除される
+  has_many :comments, dependent: :destroy
+  # dependent: :destroyを記述することによって、destroy 時に関連づけられたモデルに対して destroy が実行されるようになる
+  # 今回の場合では、掲示板が削除されたときに、そのユーザーに関連するCommentsレコードも一緒に削除される
 
   def own?(object)
     # own? メソッドについて

--- a/app/views/comments/_comment.html.erb
+++ b/app/views/comments/_comment.html.erb
@@ -1,8 +1,8 @@
- <tr id="comment-<%= comment.id %>">
+<tr id="comment-<%= comment.id %>">
   <td>
     <h3 class="small"><%= comment.user.decorate.full_name %></h3>
     <p><%= simple_format(comment.body) %></p>
-    <li class="list-inline-item" ><%= l @post.created_at, format: :long %></li>
+    <li class="list-inline-item"><%= l comment.created_at, format: :long %></li>
   </td>
   <% if current_user.own?(comment) %>
     <td class="action">
@@ -13,11 +13,11 @@
           <% end %>
         </li>
         <li class="list-inline-item">
-          <%= link_to "#", class: "delete-comment-link" do %>
+          <%= link_to comment_path(comment), class: "delete-comment-link", data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } do %>
             <i class="bi bi-trash-fill"></i>
           <% end %>
         </li>
       </ul>
     </td>
   <% end %>
- </tr>
+</tr>

--- a/app/views/comments/_form.html.erb
+++ b/app/views/comments/_form.html.erb
@@ -1,6 +1,7 @@
 <div class="row mb-3" id="comment-form">
   <div class="col-lg-8 offset-lg-2">
     <%= form_with model: comment, url: post_comments_path(post) do |f| %>
+      <%= render 'shared/error_messages', object: f.object %>
       <%= f.label :body %>
       <%= f.text_area :body, class: "form-control mb-3", row: "4", placeholder: Comment.human_attribute_name(:body) %>
       <%= f.submit t('defaults.post'), class: "btn btn-primary" %>

--- a/app/views/comments/create.turbo_stream.erb
+++ b/app/views/comments/create.turbo_stream.erb
@@ -1,0 +1,12 @@
+<% if @comment.errors.present? %>
+  <%= turbo_stream.replace "comment-form" do %>
+    <%= render 'comments/form', comment: @comment, post: @comment.post %>
+  <% end %>
+<% else %>
+  <%= turbo_stream.prepend "table-comment" do %>
+    <%= render 'comments/comment', comment: @comment %>
+  <% end %>
+  <%= turbo_stream.replace "comment-form" do %>
+    <%= render 'comments/form', comment: Comment.new, post: @comment.post %>
+  <% end %>
+<% end %>

--- a/app/views/comments/destroy.turbo_stream.erb
+++ b/app/views/comments/destroy.turbo_stream.erb
@@ -1,0 +1,6 @@
+<%= turbo_stream.remove "comment-#{@comment.id}" %>
+<%= turbo_stream.replace "comment-form" do %>
+    <%= render 'comments/form', comment: Comment.new, post: @comment.post %>
+<% end %>
+
+


### PR DESCRIPTION
## **app/controllers/comments_controller.rbを編集する**

app/controllers/comments_controller.rbを以下のように編集

```ruby
class CommentsController < ApplicationController
    def create
      # findメソッド
      # RailsのActiveRecordが提供するメソッドで、渡されたIDを元にデータベースから特定のレコードを取得する
      # 例えば、User.find(255)とすると、IDが255のUsersテーブルのレコードを取得する。
      # 存在しないIDを渡すと、ActiveRecord::RecordNotFound例外が発生する
      # @post = Post.find(params[:post_id])
      # createアクション内で params[:post_id] を使うことでURLの掲示板のIDパラメータ(65535)を取得できる
      # params はハッシュ形式でデータを保持するため、キーを指定して対応する値を取得することができる
      # @comment = @post.comments.build(comment_params)
      # @comment.user = current_user

      # if @comment.save
      # url オプションを用いることで、フォームの送信先URLを明示的に指定
      # redirect_to post_path(@post), success: t("defaults.flash_message.created", item: Comment.model_name.human)
      # else
      # @comments = @post.comments.includes(:user).order(created_at: :desc)
      # flash.now[:danger] = t("defaults.flash_message.not_created", item: Comment.model_name.human)
      # render "posts/show", status: :unprocessable_entity
      # end
      @comment = current_user.comments.build(comment_params)
      @comment.save
    end

    def destroy
      @comment = current_user.comments.find(params[:id])
      @comment.destroy!
    end

    private

    def comment_params
      params.require(:comment).permit(:body).merge(post_id: params[:post_id])
    end
end
```

### **app/views/comments/_comment.html.erbを編集する**

app/views/comments/_comment.html.erbを以下のように編集

```html
<tr id="comment-<%= comment.id %>">
  <td>
    <h3 class="small"><%= comment.user.decorate.full_name %></h3>
    <p><%= simple_format(comment.body) %></p>
    <li class="list-inline-item"><%= l comment.created_at, format: :long %></li>
  </td>
  <% if current_user.own?(comment) %>
    <td class="action">
      <ul class="list-inline justify-content-center" style="float: right;">
        <li class="list-inline-item">
          <%= link_to "#", class: "edit-comment-link" do %>
            <i class="bi bi-pencil-fill"></i>
          <% end %>
        </li>
        <li class="list-inline-item">
          <%= link_to comment_path(comment), class: "delete-comment-link", data: { turbo_method: :delete, turbo_confirm: t('defaults.delete_confirm') } do %>
            <i class="bi bi-trash-fill"></i>
          <% end %>
        </li>
      </ul>
    </td>
  <% end %>
</tr>
```

`@post.created_at` にアクセスしようとしている際に `@post` が `nil` であるため、エラーが発生するので、`_comment.html.erb` 内でコメントの投稿日時を表示する場合は、`@post.created_at` ではなく、`comment.created_at` を使用する必要がある

## **app/views/comments/_form.html.erbを編集する**

app/views/comments/_form.html.erbを以下のように編集

```html
<div class="row mb-3" id="comment-form">
  <div class="col-lg-8 offset-lg-2">
    <%= form_with model: comment, url: post_comments_path(post) do |f| %>
     <!--追加,shared/error_messagesのフォームから紐づく-->
      <%= render 'shared/error_messages', object: f.object %>
      <%= f.label :body %>
      <%= f.text_area :body, class: "form-control mb-3", row: "4", placeholder: Comment.human_attribute_name(:body) %>
      <%= f.submit t('defaults.post'), class: "btn btn-primary" %>
    <% end %>
  </div>
</div>
```

## **app/views/comments/create.turbo_stream.erbを生成・編集する**

app/views/comments/create.turbo_stream.erbを生成して、以下のように編集

```ruby
<% if @comment.errors.present? %>
  <%= turbo_stream.replace "comment-form" do %>
    <%= render 'comments/form', comment: @comment, board: @comment.board %>
  <% end %>
<% else %>
  <%= turbo_stream.prepend "table-comment" do %>
    <%= render 'comments/comment', comment: @comment %>
  <% end %>
  <%= turbo_stream.replace "comment-form" do %>
    <%= render 'comments/form', comment: Comment.new, board: @comment.board %>
  <% end %>
<% end %>
```

まとめると、

このコードは、コメントが正常に追加されると、

コメントリストの最初に新しいコメントが表示され、

フォームがリセットされる

```ruby
<% if @comment.errors.present? %>
  <%= turbo_stream.replace "comment-form" do %>
    <%= render 'comments/form', comment: @comment, board: @comment.board %>
  <% end %>

```

まず、@comment にエラーがあるかどうかを確認している

エラーが存在する場合、フォームをエラーメッセージ付きで再表示する必要があり、このチェックは <% if @comment.errors.present? %> の部分で行われている

エラーがある場合、comment-formというIDを持つ要素を、新しいフォームの内容で置き換える

これにより、エラーメッセージが表示された状態のフォームが表示される

この処理は、<%= turbo_stream.replace "comment-form" do %>の部分で実現されている

```ruby
<%= turbo_stream.prepend "table-comment" do %>
  <%= render 'comments/comment', comment: @comment %>
<% end %>

```

エラーがない場合、新しいコメントをコメントリストの最初に追加する

table-comment という ID を持つ要素の内部の先頭に、新しいコメントの部分テンプレートを追加し、新しいコメントがリストの最初に表示される

### **Prepend**

Turbo Streamの代表的なアクションの一つ

指定した要素の内部の最初に新しいコンテンツを追加する

具体的には、以下のように使用する

```ruby
<%= turbo_stream.prepend "comments" do %>
  <%= render @comment %>
<% end %>
```

このコードは、comments という ID を持つ要素の内部の最初に、@comment の部分テンプレートを追加する

これにより、新しいコメントがリストの先頭に追加される

Prepend アクションは、新しい要素を既存のコンテンツの前に追加する際に使用する

```ruby
<%= turbo_stream.replace "comment-form" do %>
  <%= render 'comments/form', comment: Comment.new, board: @comment.board %>
<% end %>

```

新しいコメントが追加された後、コメントフォームを削除する

これにより、ユーザーがすぐに新しいコメントを入力できるようになる

### **Replace**

Turbo Streamの代表的なアクションの一つ
指定した要素を削除する
具体的には、以下のように使用する

```ruby
<%= turbo_stream.replace "comment_#{@comment.id}" do %>
<%= render @comment %>
<% end %>

```

このコードは、comment_#{@comment.id} という ID を持つ要素を、@comment の部分テンプレートで置き換える
これにより、編集後のコメントが元のコメントと入れ替わる
Replaceアクションは、既存の要素を新しい内容で置き換える際に使用する

## **app/views/comments/destroy.turbo_stream.erbを生成・編集する**

app/views/comments/destroy.turbo_stream.erbを生成して、生成されたファイルに適切な記述を行って、コメントが削除されるように実装する

```ruby
<%= turbo_stream.remove "comment-#{@comment.id}" %>
<%= turbo_stream.replace "comment-form" do %>
    <%= render 'comments/form', comment: Comment.new, post: @comment.post %>
<% end %>
```

上記のコードは
comment_#{@comment.id} という ID を持つ要素を削除
comment-formというIDを持つ要素（コメント投稿フォーム）を新しい内容で置き換える
つまり
コメントが正常に削除された後に、コメント一覧からその行を取り除き、さらにコメント投稿フォームをリセットする

### **Remove**

Turbo Streamの代表的なアクションの一つ
Remove アクションは、指定した要素を削除する
具体的には、以下のように使用する

```ruby
 <%= turbo_stream.remove "comment-#{@comment.id}" %>

```

このコードは、comment_#{@comment.id} という ID を持つ要素を削除する
これにより、指定したコメントが DOM から削除される
Remove アクションは、不要になった要素を DOM から取り除く際に使用する

### **Replace**

Turbo Streamの代表的なアクションの一つ
指定した要素を削除する
具体的には、以下のように使用する

```ruby
<%= turbo_stream.replace "comment_#{@comment.id}" do %>
<%= render @comment %>
<% end %>

```

このコードは、comment_#{@comment.id} という ID を持つ要素を、@comment の部分テンプレートで置き換える
これにより、編集後のコメントが元のコメントと入れ替わる
Replaceアクションは、既存の要素を新しい内容で置き換える際に使用する