### PR TITLE
掲示板詳細の修正(タイトルの動的化)

### DIFF
--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -1,4 +1,4 @@
-<% content_for(:title, t('.title')) %>
+<% content_for(:title, @post.title) %>
 <div class="top-wrapper">
   <div class="row mb-3">
     <div class="col-lg-8 offset-lg-2">


### PR DESCRIPTION
掲示板詳細の掲示板タイトルの動的化をしたはずが、修正ミスで抜けていたので、再修正
Before
```HTML
<% content_for(:title, t('.title')) %>
```
After
```HTML
<% content_for(:title, @post.title) %>
```
例えば、掲示板のタイトルが「ええええ」の場合、タイトルは「ええええ|ガマルジョバ」と表示する