### PR TITLE
投稿一覧実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -117,7 +117,7 @@ class PostsController < ApplicationController
     end
 
     def posts
-      # PostsControllerのpostsアクション内に、ログインユーザーの投稿を取得する処理を追加する 
+      # PostsControllerのpostsアクション内に、ログインユーザーの投稿を取得する処理を追加する
       # 現在のユーザーを取得するためにcurrent_userを使い、関連付けを活用してそのユーザーの投稿のみを取得する
       @user_posts = current_user.posts.page(params[:page]).per(10) # 10件ずつページネーション
     end

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -116,6 +116,12 @@ class PostsController < ApplicationController
       @favorite_posts = @q.result.includes(:user)
     end
 
+    def posts
+      # PostsControllerのpostsアクション内に、ログインユーザーの投稿を取得する処理を追加する 
+      # 現在のユーザーを取得するためにcurrent_userを使い、関連付けを活用してそのユーザーの投稿のみを取得する
+      @user_posts = current_user.posts.page(params[:page]).per(10) # 10件ずつページネーション
+    end
+
 
     private
 

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -5,11 +5,12 @@
      <h1><%= @recipe_info[:name] %></h1>
      </div>
       <%= image_tag @recipe_info[:image], class: "post-food-image" %>
+  </div>
       <div class="overview">
       <p>概説</p>
       <p><%= @recipe_info[:description] %></p>
       </div>  
-    </div>
+    
     <div class="container pt-3">
   <div class="row">
   </div>

--- a/app/views/posts/posts.html.erb
+++ b/app/views/posts/posts.html.erb
@@ -1,0 +1,18 @@
+<div class="top-wrapper">
+<% content_for(:title, t('.title')) %>
+<div class="container pt-3">
+  <h1>あなたの投稿一覧</h1>
+  <% if @user_posts.present? %>
+    <div class="row">
+      <% @user_posts.each do |post| %>
+        <div class="col-12 mb-3">
+          <%= render post %> <!-- 各投稿を表示する -->
+        </div>
+      <% end %>
+    </div>
+    <%= paginate @user_posts %> <!-- ページネーションの表示 -->
+  <% else %>
+    <p>まだ投稿がありません。</p>
+  <% end %>
+</div>
+</div>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -28,7 +28,8 @@
             <li class='nav-item'><%= link_to t('header.show'), profile_path , class: 'nav-link'%></li>
             <li><hr class='dropdown-divider'></li>
             <li class='nav-item'><%= link_to '「参考になった」投稿', favorites_posts_path, class: 'nav-link' %></li>
-            <li class='nav-item'><%= link_to '投稿一覧', '#', class: 'nav-link' %></li>
+            <!-- ユーザー自身が投稿したものをヘッダーの「投稿一覧」にアクセスした際に確認できるように実装 -->
+            <li class='nav-item'><%= link_to '投稿一覧', posts_posts_path, class: 'nav-link' %></li>
            </div>
           </ul>
         </li>

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -112,6 +112,8 @@ ja:
     favorites:
       title: 「参考になった」投稿
       no_result: 「参考になった」投稿はございません
+    posts:
+      title: 投稿一覧
   profiles:
     show:
       title: プロフィール設定


### PR DESCRIPTION
ユーザー自身が投稿したものをヘッダーの「投稿一覧」にアクセスした際に確認できるように実装する
1. ルートの追加
ユーザー自身の投稿のみを表示する専用のルートを定義する
routes.rbに以下のコードを追加する
```ruby
Rails.application.routes.draw do
  # 略...
  
  resources :posts do
    collection do
      get :favorites
      get :posts  # ここでユーザー自身の投稿一覧のルートを追加します
    end
  end

  # 略...
end
```
これにより、ユーザーの投稿を表示するための/posts/user_postsという新しいURLが定義される

2. コントローラーにuser_postsアクションを追加
PostsControllerに、現在ログインしているユーザーが投稿したものだけを取得するpostsアクションを追加

```ruby
class PostsController < ApplicationController
  # 略...

  def posts
    @user_posts = current_user.posts.page(params[:page]).per(10) # 10件ずつページネーション
  end

  # 略...
end
```
3. ビューの作成
app/views/posts/user_posts.html.erbというファイルを新規作成して、ユーザーが投稿した内容のみを表示するページを作成する

```HTML
<div class="top-wrapper">
<% content_for(:title, t('.title')) %>
<div class="container pt-3">
  <h1>あなたの投稿一覧</h1>
  <% if @user_posts.present? %>
    <div class="row">
      <% @user_posts.each do |post| %>
        <div class="col-12 mb-3">
          <%= render post %> <!-- 各投稿を表示する -->
        </div>
      <% end %>
    </div>
    <%= paginate @posts %> <!-- ページネーションの表示 -->
  <% else %>
    <p>まだ投稿がありません。</p>
  <% end %>
</div>
</div>
```
4. ヘッダーリンクの修正
「投稿一覧」のリンクを/posts/user_postsに変更し、ユーザーが投稿一覧にアクセスできるようにする
```
<!-- ドロップダウンメニュー -->
<ul class='dropdown-menu dropdown-menu-end custom-bg'>
  <div style='text-align: center;'>
    <li class='nav-item'><%= link_to t('header.show'), profile_path, class: 'nav-link' %></li>
    <li><hr class='dropdown-divider'></li>
    <li class='nav-item'><%= link_to '「参考になった」投稿', favorites_posts_path, class: 'nav-link' %></li>
    <li class='nav-item'><%= link_to '投稿一覧', posts_posts_path, class: 'nav-link' %></li> <!-- リンクの修正 -->
  </div>
</ul>
```