### PR TITLE
Password resets

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -124,3 +124,11 @@ group :test do
   gem "capybara"
   gem "selenium-webdriver"
 end
+
+# 送信されるメールをブラウザで確認できる時に必要
+# メールの送信処理が実行されると、メールの内容がブラウザ上で表示され、実際にメールが送信されることなく内容を確認することができる
+# これにより、メールの内容やフォーマットを簡単に確認・修正することが可能となる
+group :development do
+  gem 'letter_opener', '~> 1.7.0'
+  gem 'letter_opener_web', '~> 2.0.0'
+end

--- a/Gemfile
+++ b/Gemfile
@@ -129,6 +129,6 @@ end
 # メールの送信処理が実行されると、メールの内容がブラウザ上で表示され、実際にメールが送信されることなく内容を確認することができる
 # これにより、メールの内容やフォーマットを簡単に確認・修正することが可能となる
 group :development do
-  gem 'letter_opener', '~> 1.7.0'
-  gem 'letter_opener_web', '~> 2.0.0'
+  gem "letter_opener", "~> 1.7.0"
+  gem "letter_opener_web", "~> 2.0.0"
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -173,6 +173,15 @@ GEM
       kaminari-core (= 1.2.2)
     kaminari-core (1.2.2)
     language_server-protocol (3.17.0.3)
+    launchy (2.5.2)
+      addressable (~> 2.8)
+    letter_opener (1.7.0)
+      launchy (~> 2.2)
+    letter_opener_web (2.0.0)
+      actionmailer (>= 5.2)
+      letter_opener (~> 1.7)
+      railties (>= 5.2)
+      rexml
     logger (1.6.1)
     loofah (2.22.0)
       crass (~> 1.0.2)
@@ -403,6 +412,8 @@ DEPENDENCIES
   jquery-rails
   jsbundling-rails
   kaminari (= 1.2.2)
+  letter_opener (~> 1.7.0)
+  letter_opener_web (~> 2.0.0)
   meta-tags
   mini_magick
   pg (~> 1.1)

--- a/app/views/profiles/edit.html.erb
+++ b/app/views/profiles/edit.html.erb
@@ -16,7 +16,9 @@
           <%= f.label :user_name, class: "form-label" %>
           <%= f.text_field :user_name, class: "form-control custom-input" %>
         </div>
-        <%= f.submit class: "btn btn-primary" %>
+        <div class="text-center mt-3">
+         <%= f.submit class: "btn btn-primary" %>
+        </div>
       <% end %>
       <div class='text-center'>
         <%= link_to t('.to_login_page'), login_path %>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -16,11 +16,6 @@
           <%= f.password_field :password, class: "form-control custom-input" %>
         </div>
 
-        <!-- 「パスワードをお忘れの方はこちら」のリンク -->
-        <div class='text-center'>
-          <%= link_to t('user_sessions.new.password_forget'), '#', class: 'custom-link' %>
-        </div>
-
         <!-- ログインボタン -->
         <div class="text-center mt-3">
           <%= f.submit t('user_sessions.new.login'), class: "orange" %>
@@ -31,6 +26,11 @@
       <div class='text-center mt-3'>
         <%= link_to t('user_sessions.new.to_register_page'), new_user_path, class: 'custom-link' %>
       </div>
+
+      <!-- 「パスワードをお忘れの方はこちら」のリンク -->
+        <div class='text-center'>
+          <%= link_to t('user_sessions.new.password_forget'), '#', class: 'custom-link' %>
+        </div>
     </div>
   </div>
 </div>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -1,5 +1,6 @@
 <% content_for(:title, t('.title')) %>
 <div class="top-wrapper">
+ <div class="container">
   <div class="row">
     <div class="col-md-10 col-lg-8 mx-auto">
       <div class='text-center'>
@@ -18,7 +19,7 @@
 
         <!-- ログインボタン -->
         <div class="text-center mt-3">
-          <%= f.submit t('user_sessions.new.login'), class: "orange" %>
+          <%= f.submit t('user_sessions.new.login'),class: "btn btn-primary" %>
         </div>
       <% end %>
 
@@ -33,4 +34,5 @@
         </div>
     </div>
   </div>
+ </div>
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -1,5 +1,6 @@
 <% content_for(:title, t('.title')) %>
 <div class="top-wrapper">
+ <div class="container">
   <div class="row">
     <div class="col-md-10 col-lg-8 mx-auto">
       <h1>ユーザー登録</h1>
@@ -26,4 +27,5 @@
       <% end %>
     </div>
   </div>
+ </div>
 </div>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -23,7 +23,7 @@
           <%= f.label :password_confirmation, class: "form-label" %>
           <%= f.password_field :password_confirmation, class: "form-control custom-input" %>
         </div>
-        <%= f.submit "登録する", class: "orange" %>
+        <%= f.submit "登録する", class: "btn btn-primary" %>
       <% end %>
     </div>
   </div>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -49,6 +49,13 @@ Rails.application.routes.draw do
   # ユーザーがログアウトボタンをクリックすると、サーバーによってセッションが破棄され、その後ユーザーはログイン画面やホームページにリダイレクトされる流れになる
   delete "logout", to: "user_sessions#destroy"
 
+  # ルート側にpassword_resets(パスワードリセット)を追加
+  # resources :password_resets, only: [:new, :create, :edit, :update]を記載することで、
+  # パスワードリセット画面表示と新規パスワード作成,編集、更新のルーティングが設定される
+  # 新しいパスワードを再設定するためのフォーム、およびUserモデル内のパスワードを変更するためのフォームが必要になるので、
+  # config/routes.rbにnew、create、edit、updateのルーティングも用意するという意味合い
+  resources :password_resets, only: [ :new, :create, :edit, :update ]
+
   # ルート側にposts(掲示板機能)を追加
   # resourcesメソッドのonlyオプションにnewを記載することで、GETメソッドで /posts/new というURLパターンにリクエストが飛んだ際に postsコントローラーのnewアクションが動くように定義される
   # resources :users, only: %i[new create]


### PR DESCRIPTION
パスワードリセットの事前準備
# **gem 'letter_opener_web'**

gem 'letter_opener_web'は、Railsアプリケーションの開発環境において、送信されるメールをブラウザで確認できるgem

メールの送信処理が実行されると、メールの内容がブラウザ上で表示され、実際にメールが送信されることなく内容を確認することができます。これにより、メールの内容やフォーマットを簡単に確認・修正することが可能となる

パスワードリセットの実装の中では一番簡単にできるGemの一つ
 # ルート側にpassword_resets(パスワードリセット)を追加
今回の実装では、新しいパスワードを再設定するためのフォーム、およびUserモデル内のパスワードを変更するためのフォームが必要になるので、config/routes.rbにnew、create、edit、updateのルーティングも用意する
```Ruby
 # ルート側にpassword_resets(パスワードリセット)を追加
  # resources :password_resets, only: [:new, :create, :edit, :update]を記載することで、
  # パスワードリセット画面表示と新規パスワード作成,編集、更新のルーティングが設定される
  # 新しいパスワードを再設定するためのフォーム、およびUserモデル内のパスワードを変更するためのフォームが必要になるので、
  # config/routes.rbにnew、create、edit、updateのルーティングも用意するという意味合い
  resources :password_resets, only: [ :new, :create, :edit, :update ]
```
ログインフォームのHTMLを修正
Before
[![Image from Gyazo](https://i.gyazo.com/5f2dc4faae888808b1f614e91ee7100f.gif)](https://gyazo.com/5f2dc4faae888808b1f614e91ee7100f)
After
[![Image from Gyazo](https://i.gyazo.com/a734a545d6c2244a05fea40ff55ca85d.gif)](https://gyazo.com/a734a545d6c2244a05fea40ff55ca85d)