### PR TITLE
デプロイするための微修正

### DIFF
--- a/app/views/diagnoses/show.html.erb
+++ b/app/views/diagnoses/show.html.erb
@@ -15,7 +15,7 @@
     <!-- 111 の場合（オジャフリ） -->
     <% if @diagnosis.question == "112" %>
       <div class="image-container">
-        <img src="/assets/Answer01.png" alt="オジャフリ" class="answer-image">
+        <%= image_tag 'Answer01.png', alt: 'オジャフリ', class: 'answer-image' %>
         <div class="text-overlay">
           <h6>オジャフリ</h6>
           <div class = "noto-serif-georgian-uniquifier">
@@ -41,7 +41,7 @@
     <!-- 121 の場合（パドリジャーニ） -->
     <% elsif @diagnosis.question == "212" %>
       <div class="image-container">
-        <img src="/assets/Answer02.png" alt="パドリジャーニ" class="answer-image">
+        <%= image_tag 'Answer02.png', alt: 'パドリジャーニ', class: 'answer-image' %>
         <div class="text-overlay">
           <h6>パドリジャーニ</h6>
           <div class = "noto-serif-georgian-uniquifier">
@@ -67,7 +67,7 @@
     <!-- 122 の場合（ソコスチャシュシュリ） -->
     <% elsif @diagnosis.question == "122" %>
       <div class="image-container">
-        <img src="/assets/Answer03.png" alt="ソコスチャシュシュリ" class="answer-image">
+        <%= image_tag 'Answer03.png', alt: 'ソコスチャシュシュリ', class: 'answer-image' %>
         <div class="text-overlay">
           <h6>ソコスチャシュシュリ</h6>
           <div class = "noto-serif-georgian-uniquifier">
@@ -92,6 +92,7 @@
     <!-- 222 の場合（プパリ） -->
     <% elsif @diagnosis.question == "222" %>
       <div class="image-container">
+        <%= image_tag 'Answer03.png', alt: 'ソコスチャシュシュリ', class: 'answer-image' %>
         <img src="/assets/Answer04.png" alt="プパリ" class="answer-image">
         <div class="text-overlay">
           <h6>プパリ</h6>
@@ -119,7 +120,7 @@
     <!-- 121 の場合（オーストリ） -->
     <% elsif @diagnosis.question == "121" %>
       <div class="image-container">
-        <img src="/assets/Answer05.png" alt="オーストリ" class="answer-image">
+        <%= image_tag 'Answer05.png', alt: 'オーストリ', class: 'answer-image' %>
         <div class="text-overlay">
           <h6>オーストリ</h6>
           <div class = "noto-serif-georgian-uniquifier">
@@ -145,7 +146,7 @@
     <!-- 221 の場合（チヒルトゥマ） -->
     <% elsif @diagnosis.question == "221" %>
       <div class="image-container">
-        <img src="/assets/Answer06.png" alt="チヒルトゥマ" class="answer-image">
+        <%= image_tag 'Answer06.png', alt: 'チヒルトゥマ', class: 'answer-image' %>
         <div class="text-overlay">
           <h6>チヒルトゥマ</h6>
           <div class = "noto-serif-georgian-uniquifier">
@@ -171,7 +172,7 @@
     <!-- 111 の場合（シュクメルリ） -->
     <% elsif @diagnosis.question == "111" %>
       <div class="image-container">
-        <img src="/assets/Answer07.png" alt="シュクメルリ" class="answer-image">
+        <%= image_tag 'Answer07.png', alt: 'シュクメルリ', class: 'answer-image' %>
         <div class="text-overlay">
           <h6>シュクメルリ</h6>
           <div class = "noto-serif-georgian-uniquifier">
@@ -198,7 +199,7 @@
     <!-- 211 の場合（チャホフビリ） -->
     <% elsif @diagnosis.question == "211" %>
       <div class="image-container">
-        <img src="/assets/Answer08.png" alt="チャホフビリ" class="answer-image">
+        <%= image_tag 'Answer08.png', alt: 'チャホフビリ', class: 'answer-image' %>
         <div class="text-overlay">
           <h6>チャホフビリ</h6>
           <div class = "noto-serif-georgian-uniquifier">

--- a/app/views/static_pages/food.html.erb
+++ b/app/views/static_pages/food.html.erb
@@ -41,7 +41,7 @@
   </div>
   <!-- 画像 -->
        <div class="food-container">
-         <img src="/assets/Image05.png" alt="イメージ5" class="image05">
-         <img src="/assets/Image06.png" alt="イメージ6" class="image06">
+         <%= image_tag 'Image05.png', alt: 'イメージ5', class: 'image05' %>
+         <%= image_tag 'Image06.png', alt: 'イメージ6', class: 'image06' %>
        </div>
 </div>

--- a/app/views/static_pages/georgia.html.erb
+++ b/app/views/static_pages/georgia.html.erb
@@ -23,7 +23,7 @@
     </div>
     <!-- 画像 -->
     <div class="food-container">
-     <img src="/assets/Georgia.gif" alt="ジョージアの位置" class="georgia">
-     <img src="/assets/Image02.png" alt="普通のブドウ" class="image02">
+     <%= image_tag 'Georgia.gif', alt: 'ジョージアの位置', class: 'georgia' %>
+     <%= image_tag 'Image02.png', alt: '普通のブドウ', class: 'image02' %>
     </div>
 </div>


### PR DESCRIPTION
デプロイした画面でチェックしていますが、 ログインログアウト、 診断機能、 プロフィール編集ができているのは確認取れました その一方で 下記のhtmlにおける画像が表示されない問題が起きた

**原因**
Railsでは画像を表示する際に、asset_pathやimage_tagを使うのが一般的
直接/assets/を指定すると、デプロイ環境で正しくパスが解決されないことがある

**解決方法**
Before
```HTML
<img src="/assets/Answer01.png" alt="オジャフリ" class="answer-image">
```
After
```HTML
<%= image_tag 'Answer01.png', alt: 'オジャフリ', class: 'answer-image' %>
```