### PR TITLE
デプロイ環境に修正

### DIFF
--- a/app/uploaders/post_image_uploader.rb
+++ b/app/uploaders/post_image_uploader.rb
@@ -63,8 +63,8 @@ class PostImageUploader < CarrierWave::Uploader::Base
 
 
   # board_imageカラムに値が無い場合は、300 x 200 画像（board_placeholder.png）を表示するように設定
-  def default_url
-    "post_placeholder"
+  def default_url(*args)
+    ActionController::Base.helpers.asset_path("post_placeholder.png") # 拡張子に合わせて修正
   end
 
   # 画像を300x200にリサイズして切り抜き

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -7,7 +7,7 @@
         <div class="card-body">
           <div class="row">
             <div class="col-md-3">
-              <%= image_tag @post.post_image_url, width: "300", height: "200", class: "card-img-top img-fluid" %>
+              <%= image_tag @post.post_image_url || asset_path("post_placeholder.png"), width: "300", height: "200", class: "card-img-top img-fluid" %>
             </div>
             <div class="col-md-9">
               <h3 style="display: inline;"><%= @post.title %></h3>


### PR DESCRIPTION
fly.io(本番環境)上にて投稿しようとすると下記のエラーが表示された 
```
We're sorry, but something went wrong. If you are the application owner check the logs for more information.
```
### 原因
エラーログを確認すると、問題は次の通り
```
Sprockets::Rails::Helper::AssetNotFound (The asset "post_placeholder" is not present in the asset pipeline.
```
確認したところ、post_placeholder というアセット（画像などのファイル）が、アセットパイプラインに存在しないために発生するエラー
アプリケーションが本番環境でこのアセットを見つけられず、500 Internal Server Errorを返している

### 1. post_placeholder アセットの確認
post_placeholder という画像がアセットディレクトリに存在しているか確認する
アセットディレクトリは通常 app/assets/images にあり、ここに post_placeholder.png や post_placeholder.jpg といったファイルが含まれていることが必要

### 2. post_placeholder アセットの確認
2. アセットプリコンパイルの再確認
アセットプリコンパイルの結果として public/assets に post_placeholder ファイルが出力されることを確認

```bash
RAILS_ENV=production bundle exec rails assets:precompile
```
プリコンパイル後、public/assets 内に該当のアセットが含まれているか確認

### 3. default_url メソッドの修正
default_url メソッド内の戻り値の記述が原因で、画像が見つからない可能性がある
現在のコードでは単に "post_placeholder" としているため、Sprockets (アセットパイプライン) で正しく解釈されていない

修正案：
default_url メソッドで、アセットパイプライン経由の正しいパスを設定する必要があります。以下のように記述を変更してみ
る
```ruby
def default_url(*args)
  ActionController::Base.helpers.asset_path("post_placeholder.png") # 拡張子に合わせて修正
end
```
これにより、Rails のアセットパイプライン経由で post_placeholder.png を探しに行くようになる

### 4. image_tag の使い方確認
デフォルト画像が表示されない場合に備えて、CarrierWave を利用してデフォルト画像を表示する設定に加え、 image_tag にも明示的にデフォルト画像を指定できる

```HTML
<%= image_tag @post.post_image_url || asset_path("post_placeholder.png"), width: "300", height: "200", class: "card-img-top img-fluid" %>
```
これにより、@post.post_image_url が nil の場合に post_placeholder.png を表示するようになる

### 5. プリコンパイルと再デプロイ
修正を行った後、必ず本番環境のプリコンパイルを再実行し、再デプロイを行う

```bash
RAILS_ENV=production bundle exec rails assets:precompile
fly deploy
```