### PR TITLE
パスワードリセット

### DIFF
--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -86,18 +86,18 @@ Rails.application.configure do
 
   config.action_mailer.delivery_method = :smtp
   config.action_mailer.smtp_settings = {
-    address:              'smtp.gmail.com',
+    address:              "smtp.gmail.com",
     port:                 587,
-    domain:               'example.com', # 自分のドメイン名
-    user_name:            ENV['SMTP_USERNAME'], # Gmailアカウント
-    password:             ENV['SMTP_PASSWORD'], # Gmailアカウントのパスワード
-    authentication:       'plain',
+    domain:               "example.com", # 自分のドメイン名
+    user_name:            ENV["SMTP_USERNAME"], # Gmailアカウント
+    password:             ENV["SMTP_PASSWORD"], # Gmailアカウントのパスワード
+    authentication:       "plain",
     enable_starttls_auto: true
   }
 
-  config.action_mailer.default_url_options = { host: 'your-production-domain.com', protocol: 'https' }
+  config.action_mailer.default_url_options = { host: "your-production-domain.com", protocol: "https" }
   # Fly.io ドメインを使用している場合:
-  config.action_mailer.default_url_options = { host: 'gamarjoba.fly.dev', protocol: 'https' }
+  config.action_mailer.default_url_options = { host: "gamarjoba.fly.dev", protocol: "https" }
 
 
   # Ignore bad email addresses and do not raise email delivery errors.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -96,7 +96,8 @@ Rails.application.configure do
   }
 
   config.action_mailer.default_url_options = { host: 'your-production-domain.com', protocol: 'https' }
-
+  # Fly.io ドメインを使用している場合:
+  config.action_mailer.default_url_options = { host: 'gamarjoba.fly.dev', protocol: 'https' }
 
 
   # Ignore bad email addresses and do not raise email delivery errors.

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -83,6 +83,22 @@ Rails.application.configure do
   # 本番環境では、メール内でリンクを生成するためにホスト名が必要ですが、それが指定されていない
   config.action_mailer.default_url_options = { host: "your-production-domain.com", protocol: "https" }
   # この設定により、メール内で生成されるリンク（edit_password_reset_urlなど）が正しいホスト名を持つようになる
+
+  config.action_mailer.delivery_method = :smtp
+  config.action_mailer.smtp_settings = {
+    address:              'smtp.gmail.com',
+    port:                 587,
+    domain:               'example.com', # 自分のドメイン名
+    user_name:            ENV['SMTP_USERNAME'], # Gmailアカウント
+    password:             ENV['SMTP_PASSWORD'], # Gmailアカウントのパスワード
+    authentication:       'plain',
+    enable_starttls_auto: true
+  }
+
+  config.action_mailer.default_url_options = { host: 'your-production-domain.com', protocol: 'https' }
+
+
+
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.
   # config.action_mailer.raise_delivery_errors = false


### PR DESCRIPTION
### **本番環境にてパスワードリセット機能を実装すると、下記のエラーが発生**
エラーログに記録されているエラー：

````arduino
Errno::ECONNREFUSED (Connection refused - connect(2) for "localhost" port 25):
````
これは、メール送信時にデフォルトで使用されるlocalhost:25のSMTPサーバーが利用できないことを示している
本番環境では、開発環境のletter_openerとは異なり、実際のSMTPサーバーを通じてメールを送信する必要がある

### **解決方法**

### 1. SMTPサーバーの設定を追加する

本番環境でメール送信を正しく行うために、SMTPの設定を追加する

config/environments/production.rbにSMTP設定を追加
以下のように、SMTPサーバー（例: Gmail、SendGridなど）を設定する
ここではGmailを例に
````Ruby
Rails.application.configure do
  # 他の設定

  config.action_mailer.delivery_method = :smtp
  config.action_mailer.smtp_settings = {
    address:              'smtp.gmail.com',
    port:                 587,
    domain:               'example.com', # 自分のドメイン名
    user_name:            ENV['SMTP_USERNAME'], # Gmailアカウント
    password:             ENV['SMTP_PASSWORD'], # Gmailアカウントのパスワード
    authentication:       'plain',
    enable_starttls_auto: true
  }

  config.action_mailer.default_url_options = { host: 'your-production-domain.com', protocol: 'https' }

  # Fly.io ドメインを使用している場合:
  # config.action_mailer.default_url_options = { host: 'gamarjoba.fly.dev', protocol: 'https' }
end
````

### 2. 環境変数の設定

メールアカウント情報（SMTP_USERNAMEとSMTP_PASSWORD）を環境変数に設定する

Fly.ioを使用している場合、Fly CLIで環境変数を設定できる

**注意**

GmailのSMTPサーバーは、アカウントのセキュリティ設定が標準のパスワードではなく、アプリ パスワードを必要としていることを示す

- アプリ パスワードの生成

Gmailアカウントで、次の手順でアプリ パスワードを生成

- Googleアカウントのセキュリティ設定にアクセス

「2段階認証プロセス」が有効になっていることを確認
「アプリ パスワード」のセクションに移動
使用するアプリとデバイスを選択して新しいパスワードを生成

````bash
fly secrets set SMTP_USERNAME=your_gmail_username SMTP_PASSWORD=your_gmail_password
````
または、使用しているSMTPサービスの認証情報をFly.ioに設定

### 3. 設定を反映
設定を変更した後、アプリケーションを再デプロイ

````bash
fly deploy
````