### PR TITLE
rspec実装

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -141,6 +141,7 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
+  gem "webdrivers", require: !ENV["SELENIUM_DRIVER_URL"]
 end
 
 # gem 'letter_opener_web'は、Railsアプリケーションの開発環境において、送信されるメールをブラウザで確認できるgem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -454,6 +454,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webdrivers (5.2.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (~> 4.0)
     webrick (1.8.1)
     websocket (1.2.11)
     websocket-driver (0.7.6)
@@ -507,6 +511,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  webdrivers
 
 BUNDLED WITH
    2.5.18


### PR DESCRIPTION
webdriversのインストール
gemfileにて下記を記述して、
```
bundle install
```
```Ruby
 gem "capybara"
 gem "selenium-webdriver"
 gem "webdrivers", require: !ENV["SELENIUM_DRIVER_URL"]
```
参考リンク先では
Docker環境とローカル環境の両方で動かせるようにしたいという事情がある場合、
```
gem 'webdrivers', require: !ENV['SELENIUM_DRIVER_URL']
```
にしておくことで、「環境変数を設定しているコンテナで利用する場合はwebdriversを読み込まない」という形にできる
https://masuyama13.hatenablog.com/entry/2021/01/10/225038