### PR TITLE
System test

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -141,7 +141,7 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
-  gem "webdrivers", require: !ENV["SELENIUM_DRIVER_URL"]
+  # gem "webdrivers", "~> 5.0", require: false
 end
 
 # gem 'letter_opener_web'は、Railsアプリケーションの開発環境において、送信されるメールをブラウザで確認できるgem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -511,7 +511,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
-  webdrivers
+  webdrivers (~> 5.0)
 
 BUNDLED WITH
    2.5.18

--- a/compose.yml
+++ b/compose.yml
@@ -28,11 +28,18 @@ services:
       - node_modules:/myapp/node_modules
     environment:
       TZ: Asia/Tokyo
+      SELENIUM_DRIVER_URL: http://chrome:4444/wd/hub
     ports:
       - "3000:3000"
     depends_on:
       db:
         condition: service_healthy
+  chrome:
+    image: seleniarm/standalone-chromium:latest
+    ports:
+      - "4444:4444"
+    environment:
+      - SE_NODE_SESSION_TIMEOUT=60
 volumes:
   bundle_data:
   postgresql_data:

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -1,10 +1,35 @@
 # spec/support/capybara.rbファイル
 # capybaraの設定を書いていく
-Capybara.register_driver :remote_chrome do |app|
-    options = Selenium::WebDriver::Chrome::Options.new
-    options.add_argument('no-sandbox')
-    options.add_argument('headless')
-    options.add_argument('disable-gpu')
-    options.add_argument('window-size=1680,1050')
-    Capybara::Selenium::Driver.new(app, browser: :remote, url: ENV['SELENIUM_DRIVER_URL'], capabilities: options)
-end
+
+RSpec.configure do |config|
+    config.before(:each, type: :system) do
+      driven_by :remote_chrome
+      Capybara.server_host = IPSocket.getaddress(Socket.gethostname)
+      Capybara.server_port = 4444
+      Capybara.app_host = "http://#{Capybara.server_host}:#{Capybara.server_port}"
+    end
+  
+    config.before(:each, type: :system, js: true) do
+      driven_by :remote_chrome
+      Capybara.server_host = IPSocket.getaddress(Socket.gethostname)
+      Capybara.server_port = 4444
+      Capybara.app_host = "http://#{Capybara.server_host}:#{Capybara.server_port}"
+    end
+  end
+  
+  # Chrome
+  Capybara.register_driver :remote_chrome do |app|
+    url = 'http://chrome:4444/wd/hub'
+    caps = ::Selenium::WebDriver::Remote::Capabilities.chrome(
+      'goog:chromeOptions' => {
+        'args' => [
+          'no-sandbox',
+          'headless',
+          'disable-gpu',
+          'window-size=1680,1050'
+        ]
+      }
+    )
+    Capybara::Selenium::Driver.new(app, browser: :remote, url: url, desired_capabilities: caps)
+  end
+  

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -8,7 +8,7 @@ RSpec.configure do |config|
       Capybara.server_port = 4444
       Capybara.app_host = "http://#{Capybara.server_host}:#{Capybara.server_port}"
     end
-  
+
     config.before(:each, type: :system, js: true) do
       driven_by :remote_chrome
       Capybara.server_host = IPSocket.getaddress(Socket.gethostname)
@@ -16,7 +16,7 @@ RSpec.configure do |config|
       Capybara.app_host = "http://#{Capybara.server_host}:#{Capybara.server_port}"
     end
   end
-  
+
   # Chrome
   Capybara.register_driver :remote_chrome do |app|
     url = 'http://chrome:4444/wd/hub'
@@ -32,4 +32,3 @@ RSpec.configure do |config|
     )
     Capybara::Selenium::Driver.new(app, browser: :remote, url: url, desired_capabilities: caps)
   end
-  

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,0 +1,27 @@
+require 'rails_helper'
+
+RSpec.describe 'ユーザー登録', type: :system do
+  context '入力情報正常系' do
+    it 'ユーザーが新規作成できること' do
+      visit '/users/new'
+      expect {
+        fill_in 'user name', with: 'らんてっくたろう'
+        fill_in 'Email', with: 'example@example.com'
+        fill_in 'Password', with: '12345678'
+        fill_in 'Password confirmation', with: '12345678'
+        click_button '登録'
+        Capybara.assert_current_path("/", ignore_query: true)
+      }.to change { User.count }.by(1)
+    end
+  end
+
+  context '入力情報異常系' do
+    it 'ユーザーが新規作成できない' do
+      visit '/users/new'
+      expect {
+        fill_in 'Email', with: 'example@example.com'
+        click_button '登録'
+      }.to change { User.count }.by(0)
+    end
+  end
+end


### PR DESCRIPTION
```
itok1000@ItoKen:~/graduation$ docker compose exec web bundle exec rspec

ユーザー登録
  入力情報正常系
    ユーザーが新規作成できること (FAILED - 1)
  入力情報異常系
    ユーザーが新規作成できない (FAILED - 2)

Failures:

  1) ユーザー登録 入力情報正常系 ユーザーが新規作成できること
     Got 0 failures and 2 other errors:

     1.1) Failure/Error: visit '/users/new'
          
          Capybara::DriverNotFoundError:
            no driver called :remote_chrome was found, available drivers: :rack_test, :selenium, :selenium_headless, :selenium_chrome, :selenium_chrome_headless
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/session.rb:104:in `driver'
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/session.rb:92:in `initialize'
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara.rb:422:in `new'
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara.rb:422:in `block in session_pool'
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara.rb:317:in `current_session'
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/dsl.rb:46:in `page'
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/dsl.rb:52:in `visit'
          # ./spec/system/users_spec.rb:6:in `block (3 levels) in <top (required)>'

     1.2) Failure/Error: raise Capybara::DriverNotFoundError, "no driver called #{mode.inspect} was found, available drivers: #{other_drivers.join(', ')}"
          
          Capybara::DriverNotFoundError:
            no driver called :remote_chrome was found, available drivers: :rack_test, :selenium, :selenium_headless, :selenium_chrome, :selenium_chrome_headless
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/session.rb:104:in `driver'
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/session.rb:92:in `initialize'
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara.rb:422:in `new'
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara.rb:422:in `block in session_pool'
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara.rb:317:in `current_session'
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/dsl.rb:46:in `page'

  2) ユーザー登録 入力情報異常系 ユーザーが新規作成できない
     Got 0 failures and 2 other errors:

     2.1) Failure/Error: visit '/users/new'
          
          Capybara::DriverNotFoundError:
            no driver called :remote_chrome was found, available drivers: :rack_test, :selenium, :selenium_headless, :selenium_chrome, :selenium_chrome_headless
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/session.rb:104:in `driver'
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/session.rb:92:in `initialize'
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara.rb:422:in `new'
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara.rb:422:in `block in session_pool'
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara.rb:317:in `current_session'
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/dsl.rb:46:in `page'
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/dsl.rb:52:in `visit'
          # ./spec/system/users_spec.rb:20:in `block (3 levels) in <top (required)>'

     2.2) Failure/Error: raise Capybara::DriverNotFoundError, "no driver called #{mode.inspect} was found, available drivers: #{other_drivers.join(', ')}"
          
          Capybara::DriverNotFoundError:
            no driver called :remote_chrome was found, available drivers: :rack_test, :selenium, :selenium_headless, :selenium_chrome, :selenium_chrome_headless
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/session.rb:104:in `driver'
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/session.rb:92:in `initialize'
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara.rb:422:in `new'
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara.rb:422:in `block in session_pool'
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara.rb:317:in `current_session'
          # /usr/local/bundle/gems/capybara-3.40.0/lib/capybara/dsl.rb:46:in `page'

Finished in 0.0257 seconds (files took 1.99 seconds to load)
2 examples, 2 failures

Failed examples:

rspec ./spec/system/users_spec.rb:5 # ユーザー登録 入力情報正常系 ユーザーが新規作成できること
rspec ./spec/system/users_spec.rb:19 # ユーザー登録 入力情報異常系 ユーザーが新規作成できない
```
Dockerコンテナで使用する Rubyイメージには、システムスペックを実行する際に必要なブラウザ（Google Crome）がインストールされておらず、システムスペックを実行できないようだ
「docker-compose.yml」修正したり、「Gemfile」修正してるけど思った成果が出せないのが現実