### PR TITLE
Google認証(本番環境はデプロイすると失敗するので、代替措置)

### DIFF
--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -35,7 +35,7 @@
         <br>
         <!-- 「Googleログインの方はこちら」のリンク -->
         <div class='text-center text-sm'>
-          または
+          ※Google認証現在工事中
         </div>
          <div class='text-center'>
           <%= link_to auth_at_provider_path(provider: :google), data: { turbo: false } do %>


### PR DESCRIPTION
本番環境でデプロイすると
エラーログで下記に躓きデプロイできないので、修正し、マイグレダウンさせたうえ、デプロイ
なるべくほかのユーザーにも知らせるため代替措置として「※Google認証現在工事中」と記載

# エラーの原因:
```
PG::DuplicateTable: ERROR:  relation "authentications" already exists
```
このエラーは、authentications テーブルがすでに存在しているため、マイグレーションが失敗していることを示している

ところがfly.io環境でコンソール探せず、視界が悪くなっている
```
itok1000@ItoKen:~/graduation$ fly ssh console -a gamarjoba
Connecting to fdaa:b:4994:a7b:ff:dd96:42ea:2... complete
root@7811616a963668:/rails# itfly ssh console -a gamarjobaostgres -d myapp_development
Connecting to fdaa:b:4994:a7b:ff:dd96:42ea:2... complete
root@7811616a963668:/rails# itok1000@ItoKen:~/graduation$ fly ssh console -a gamarjoba
Connecting to fdaa:b:4994:a7b:ff:dd96:42ea:2... complete
root@7811616a963668:/rails# psql -U postgres -d myapp_development
psql: error: connection to server on socket "/var/run/postgresql/.s.PGSQL.5432" failed: No such file or directory
        Is the server running locally and accepting connections on that socket?
```