### PR TITLE
Google

### DIFF
--- a/db/migrate/20241205063906_sorcery_external.rb
+++ b/db/migrate/20241205063906_sorcery_external.rb
@@ -9,6 +9,6 @@ class SorceryExternal < ActiveRecord::Migration[7.2]
       end
     end
     # さらに、インデックスの追加もチェックしている
-    add_index :authentications, [:provider, :uid] unless index_exists?(:authentications, [:provider, :uid])
+    add_index :authentications, [ :provider, :uid ] unless index_exists?(:authentications, [ :provider, :uid ])
   end
 end

--- a/db/migrate/20241205063906_sorcery_external.rb
+++ b/db/migrate/20241205063906_sorcery_external.rb
@@ -1,10 +1,14 @@
 class SorceryExternal < ActiveRecord::Migration[7.2]
   def change
-    create_table :authentications do |t|
-      t.integer :user_id, null: false
-      t.string :provider, :uid, null: false
-      t.timestamps              null: false
+    # まずテーブルが存在しないか確認して、存在しなければ新しくテーブルを作成してる。
+    unless table_exists?(:authentications)
+      create_table :authentications do |t|
+        t.integer :user_id, null: false
+        t.string :provider, :uid, null: false
+        t.timestamps null: false
+      end
     end
-    add_index :authentications, [ :provider, :uid ]
+    # さらに、インデックスの追加もチェックしている
+    add_index :authentications, [:provider, :uid] unless index_exists?(:authentications, [:provider, :uid])
   end
 end


### PR DESCRIPTION
# 問題の概要
デプロイ時にマイグレーションでエラーが発生

### エラーの原因:
```arduino
PG::DuplicateTable: ERROR:  relation "authentications" already exists
```
このエラーは、authentications テーブルがすでに存在しているため、マイグレーションが失敗していることを示している

### テーブルがすでに存在する場合の対応

既存の authentications テーブルが原因でマイグレーションが失敗しているため、以下の下記の方法で解決した

# マイグレーションファイルを修正
現在のマイグレーションファイル (20241205063906_sorcery_external.rb) を修正し、authentications テーブルが存在しない場合のみ作成するように変更

修正後のマイグレーションファイル:
```ruby

class SorceryExternal < ActiveRecord::Migration[7.2]
  def change
    unless table_exists?(:authentications)
      create_table :authentications do |t|
        t.integer :user_id, null: false
        t.string :provider, :uid, null: false
        t.timestamps null: false
      end
      add_index :authentications, [:provider, :uid]
    end
  end
end
```
修正後、マイグレの中身が変わっているので、マイグレ起動中の場合は下記コマンドでマイグレを停止させ、
再度マイグレを実行させる
```arduino
rails db:rollback
docker compose exec web rails db:migrate
```

これでデプロイ問題は解決する

# デプロイ後、Googleでログインを押下すると、下記のエラーで躓く場合
[![Image from Gyazo](https://i.gyazo.com/63945f03ec6b719bb0595141e0d3fe29.png)](https://gyazo.com/63945f03ec6b719bb0595141e0d3fe29)

下記の資料を参考に、対応した
https://qiita.com/okada84108983/items/0c84c01b88072c004873#4-authentications%E3%83%86%E3%83%BC%E3%83%96%E3%83%ABauthentication%E3%83%A2%E3%83%87%E3%83%AB%E3%81%AE%E4%BD%9C%E6%88%90
https://qiita.com/rei-dev99/items/42358fe71680c804d19c

補足：本番環境のcallback_url適用
先ほどはsorcery.rbに直接callback_urlを記述しましたが、実際は開発環境と本番環境でそれぞれ異なるurlにリダイレクトさせる必要がある
以下にgem 'config'を使用した方法を記載

Gemfileにgem 'config'を追加し、bundle installを実行してインストール
config/settings/ディレクトリ下にdevelopment.ymlとproduction.ymlを作成
それぞれのファイルに開発環境、本番環境のcallback_urlを記載
config/settings/development.yml
```
sorcery:
    google_callback_url: 'http://localhost:3000/oauth/callback?provider=google'
```
config/settings/production.yml
```
sorcery:
    google_callback_url: 'https://your_app_url/oauth/callback?provider=google'
sorcery.rbの記述を変更
```
しかし、それでもエラー解消されない

そこで思い出したのが、
画像アップロード時AWS S3使ってデプロイ環境のfly.ioにS3_ACCESS_KEY_IDとS3_SECRET_ACCESS_KEYを設定したこと
```
fly secrets set AWS_ACCESS_KEY_ID=your-access-key-id AWS_SECRET_ACCESS_KEY=your-secret-access-key S3_BUCKET_NAME=your-bucket-name
```
まとめると
### GOOGLE_CLIENT_IDとGOOGLE_CLIENT_SECRETとGOOGLE_CALLBACK_URとを設定しないと、Google認証ができない

# .envにGOOGLE_CLIENT_IDとGOOGLE_CLIENT_SECRETとGOOGLE_CALLBACK_URを記載する
.env
```
GOOGLE_CLIENT_ID= Google APIで登録したクライアントキー
GOOGLE_CLIENT_SECRET= Google APIで登録したGoogle クライアント　シークレット
GOOGLE_CALLBACK_URL=あなたの作ったWebアプリ/oauth/callback?provider=google'
```
# Google APIの設定と環境変数の登録
環境変数（例：GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET, GOOGLE_CALLBACK_URL）を fly secrets を使ってFly.ioに登録
```
fly secrets set GOOGLE_CLIENT_SECRET=XXXXXXXXXXXXXXXXXXXXXXX
fly secrets set GOOGLE_CALLBACK_URL=YYYYYYYYYYYYYYYYYYYYYYYYY
fly secrets set GOOGLE_CLIENT_ID= ZZZZZZZZZZZZZZZZZZZZZZZZZZZ
```
登録成功したら、下記コマンドで登録されているかどうかを確認する
下記コマンドを打つと、情報が一覧として確認できる
```
fly secrets list
```
# デプロイ再実行
fly.ioの環境で再度デプロイしなおす
```
fly deploy
```
完了
[![Image from Gyazo](https://i.gyazo.com/39f444a3e58fbe9037fb64718c59640f.png)](https://gyazo.com/39f444a3e58fbe9037fb64718c59640f)