### PR TITLE
j18nの日本語対応が漏れてた

### DIFF
--- a/app/controllers/oauths_controller.rb
+++ b/app/controllers/oauths_controller.rb
@@ -19,7 +19,7 @@ class OauthsController < ApplicationController
           sign_up_and_login_from(provider)
           redirect_to root_path, success: t("oauths.login_success")
         rescue => e
-          Rails.logger.error "Google認証に失敗しました: #{e.message}"
+          Rails.logger.error "#{t("oauths.login_failure")}: #{e.message}"
           Rails.logger.error "バックトレース: #{e.backtrace.join("\n")}"
           redirect_to root_path, danger: t("oauths.login_failure")
         end


### PR DESCRIPTION
j18nの日本語対応が下記のように漏れてた
Before
```ruby
Rails.logger.error "Google認証に失敗しました: #{e.message}"
```
After
```ruby
Rails.logger.error "#{t("oauths.login_failure")}: #{e.message}"

```