### PR TITLE
5つ星評価のルート設定

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -69,9 +69,11 @@ Rails.application.routes.draw do
   # 投稿のリソース(一覧、新規作成、詳細、編集、削除、更新)
   # コメントのリソース(作成、編集、削除)
   # いいねのリソース(作成、削除)
+  # 5つ星評価のリソース(一覧、新規作成、詳細、削除)
   resources :posts, only: %i[index new create show edit destroy update] do
     resources :comments, only: %i[create destroy], shallow: true
     resource :favorites, only: [ :create, :destroy ]
+    resources :feedbacks, only: %i[index new create show destroy], shallow: true
 
 
      collection do


### PR DESCRIPTION
# ルート側にfeedbacks(評価機能)を追加
```Ruby
resources :feedbacks, only: %i[index new create show destroy], shallow: true
```
 を記載することで、5つ星評価のリソース(一覧、新規作成、詳細、削除)のルーティングが設定される
1つの投稿に対して1つのレビュー評価が必要だという認識なので、口コミ投稿とレビュー評価の関係は1対1の関係になる
そのため、レビュー評価は1投稿につき1回だけということなので、editは省いている

### 補足
ユーザーが投稿後にレビュー評価を変更できない場合は、updateは不要
しかし、もし投稿後にレビュー評価を変更できるようにしたい場合は、updateが必要になる
↓
投稿後にレビュー評価を変更できないようにする

### 理由

変更ができるようになるとレビューの信ぴょう性が無くなるから

Updateは不要の認識で進める