### PR TITLE
5つ星評価のモデルマイグレ修正

### DIFF
--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -34,7 +34,7 @@ class Post < ApplicationRecord
 
     has_many :feedbacks, dependent: :destroy
     # dependent: :destroyを記述することによって、destroy 時に関連づけられたモデルに対して destroy が実行されるようになる
-    
+
     # Ransack needs attributes explicitly allowlisted as searchableとエラーが出た時に追記
     # Ransackで検索を行う属性を明示的に指定する必要があるため,Postモデルにransackable_attributesメソッドを追加し、
     # 検索可能な属性を定義しなければならない

--- a/app/models/post.rb
+++ b/app/models/post.rb
@@ -32,6 +32,9 @@ class Post < ApplicationRecord
     # このコードは、Postモデルにfavorited_by?(user)メソッドを追加
     # 指定されたユーザが特定の投稿（Postインスタンス）をいいねしているかどうかを判定
 
+    has_many :feedbacks, dependent: :destroy
+    # dependent: :destroyを記述することによって、destroy 時に関連づけられたモデルに対して destroy が実行されるようになる
+    
     # Ransack needs attributes explicitly allowlisted as searchableとエラーが出た時に追記
     # Ransackで検索を行う属性を明示的に指定する必要があるため,Postモデルにransackable_attributesメソッドを追加し、
     # 検索可能な属性を定義しなければならない

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -73,7 +73,7 @@ Rails.application.routes.draw do
   resources :posts, only: %i[index new create show edit destroy update] do
     resources :comments, only: %i[create destroy], shallow: true
     resource :favorites, only: [ :create, :destroy ]
-    resources :feedbacks, only: %i[index new create show destroy], shallow: true
+    resources :feedbacks, only: %i[index new create destroy], shallow: true
 
 
      collection do

--- a/db/migrate/20241213021121_create_feedbacks.rb
+++ b/db/migrate/20241213021121_create_feedbacks.rb
@@ -1,7 +1,7 @@
 class CreateFeedbacks < ActiveRecord::Migration[7.2]
   def change
     create_table :feedbacks do |t|
-      t.integer :rating
+      t.float :rating, null: false, default: 0
       t.text :content
       t.references :post, null: false, foreign_key: true
       t.references :user, null: false, foreign_key: true

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -51,7 +51,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_13_021121) do
   end
 
   create_table "feedbacks", force: :cascade do |t|
-    t.integer "rating"
+    t.float "rating", default: 0.0, null: false
     t.text "content"
     t.bigint "post_id", null: false
     t.bigint "user_id", null: false


### PR DESCRIPTION
# 変数の変更
小数点を用いた評価をしていきたいので、マイグレを修正し、起動しているレビュー評価マイグレをダウンさせ、
下記コマンドを再実行
```
docker compose exec web rails db:migrate
```
db/migrate/20241213021121_create_feedbacks.rb
Before
```Ruby
t.integer :rating
```
After
```Ruby
t.float :rating, null: false, default: 0
```
# 1対多の法則からポスト側のモデルを修正
モデルが星レビュー評価するので、ユーザーが一つのポストを評価するという仕組みから下記を追加
dependent: :destroyを記述することによって、destroy 時に関連づけられたモデルに対して destroy が実行されるようになる
app/models/post.rb
After
```Ruby
has_many :feedbacks, dependent: :destroy
```