### PR TITLE
5つ星評価のjQueryの導入を変更

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -109,8 +109,6 @@ gem "bootsnap", require: false
 # Use Active Storage variants [https://guides.rubyonrails.org/active_storage_overview.html#transforming-images]
 # gem "image_processing", "~> 1.2"
 
-# RatyはjQueryに依存しているから、まずはjQueryをプロジェクトに追加しておく必要がある
-gem "jquery-rails"
 
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -196,10 +196,6 @@ GEM
       actionview (>= 5.0.0)
       activesupport (>= 5.0.0)
     jmespath (1.6.2)
-    jquery-rails (4.6.0)
-      rails-dom-testing (>= 1, < 3)
-      railties (>= 4.2.0)
-      thor (>= 0.14, < 2.0)
     jsbundling-rails (1.3.1)
       railties (>= 6.0.0)
     json (2.7.2)
@@ -485,7 +481,6 @@ DEPENDENCIES
   factory_bot_rails
   fog-aws
   jbuilder
-  jquery-rails
   jsbundling-rails
   kaminari (= 1.2.2)
   letter_opener

--- a/package.json
+++ b/package.json
@@ -18,6 +18,7 @@
     "autoprefixer": "^10.4.20",
     "bootstrap": "^5.3.3",
     "bootstrap-icons": "^1.11.3",
+    "jquery": "^3.7.1",
     "nodemon": "^3.1.4",
     "postcss": "^8.4.45",
     "postcss-cli": "^11.0.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -483,6 +483,11 @@ is-number@^7.0.0:
   resolved "https://registry.yarnpkg.com/is-number/-/is-number-7.0.0.tgz#7535345b896734d5f80c4d06c50955527a14f12b"
   integrity sha512-41Cifkg6e8TylSpdtTpeLVMqvSBEVzTttHvERD741+pnZ8ANv0004MRL43QKPDlK9cGvNp6NZWZUBlbGXYxxng==
 
+jquery@^3.7.1:
+  version "3.7.1"
+  resolved "https://registry.yarnpkg.com/jquery/-/jquery-3.7.1.tgz#083ef98927c9a6a74d05a6af02806566d16274de"
+  integrity sha512-m4avr8yL8kmFN8psrbFFFmB/If14iN5o9nw/NgnnM+kybDJpRsAynV2BsfpTYrTRysYUdADVD7CkUUizgkpLfg==
+
 jsonfile@^6.0.1:
   version "6.1.0"
   resolved "https://registry.yarnpkg.com/jsonfile/-/jsonfile-6.1.0.tgz#bc55b2634793c679ec6403094eb13698a6ec0aae"


### PR DESCRIPTION
## 開発環境がrails7によるjQueryの導入
jqueryを導入する際に、 "jquery-rails"というgemを使用するが、今回のようなrails7環境の場合は使用しない
下記のコマンドを実行する
```
yarn add jquery
```
webpackerの設定ファイルができないのが悩み