### PR TITLE
ユーザー新規登録のシステムスペックテスト

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -139,6 +139,7 @@ group :test do
   # Use system testing [https://guides.rubyonrails.org/testing.html#system-testing]
   gem "capybara"
   gem "selenium-webdriver"
+  gem "webdrivers"
 end
 
 # gem 'letter_opener_web'は、Railsアプリケーションの開発環境において、送信されるメールをブラウザで確認できるgem

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -450,6 +450,10 @@ GEM
       activemodel (>= 6.0.0)
       bindex (>= 0.4.0)
       railties (>= 6.0.0)
+    webdrivers (5.2.0)
+      nokogiri (~> 1.6)
+      rubyzip (>= 1.3.0)
+      selenium-webdriver (~> 4.0)
     webrick (1.8.1)
     websocket (1.2.11)
     websocket-driver (0.7.6)
@@ -502,6 +506,7 @@ DEPENDENCIES
   turbo-rails
   tzinfo-data
   web-console
+  webdrivers
 
 BUNDLED WITH
    2.5.18

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -24,6 +24,11 @@ require 'rspec/rails'
 # require only the support files necessary.
 #
 # Rails.root.glob('spec/support/**/*.rb').sort_by(&:to_s).each { |f| require f }
+# capybara等ファイルの読み込み設定
+# webdriverの設定
+# system specでテストを動かすブラウザの設定をする
+# 今回はDockerで準備しているものを指定
+Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
 
 # Checks for pending migrations and applies them before tests are run.
 # If you are not using ActiveRecord, you can remove these lines.

--- a/spec/support/capybara.rb
+++ b/spec/support/capybara.rb
@@ -17,18 +17,14 @@ RSpec.configure do |config|
     end
   end
 
-  # Chrome
+  require 'capybara/rspec'
+  require 'selenium-webdriver'
+  # capybaraの設定を書いていく
   Capybara.register_driver :remote_chrome do |app|
-    url = 'http://chrome:4444/wd/hub'
-    caps = ::Selenium::WebDriver::Remote::Capabilities.chrome(
-      'goog:chromeOptions' => {
-        'args' => [
-          'no-sandbox',
-          'headless',
-          'disable-gpu',
-          'window-size=1680,1050'
-        ]
-      }
-    )
-    Capybara::Selenium::Driver.new(app, browser: :remote, url: url, desired_capabilities: caps)
+    options = Selenium::WebDriver::Chrome::Options.new
+    options.add_argument('no-sandbox')
+    options.add_argument('headless')
+    options.add_argument('disable-gpu')
+    options.add_argument('window-size=1680,1050')
+    Capybara::Selenium::Driver.new(app, browser: :remote, url: ENV['SELENIUM_DRIVER_URL'], capabilities: options)
   end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,0 +1,80 @@
+require 'rails_helper'
+RSpec.describe "Users", type: :system do
+  
+  describe "ログイン前" do
+
+    context '入力情報異常系' do
+      it 'ユーザーが新規作成できないこと' do
+        visit '/users/new'
+        expect {
+          fill_in "user[email]", with: 'example@example.com'
+          click_button "登録する"
+        }.to change { User.count }.by(0)
+      end
+    end
+
+    context "ユーザー登録" do
+      it "フォームの入力値が正常の場合登録できること" do
+        visit "users/new"
+        expect{
+          fill_in "user[user_name]", with: "テスト太郎"
+          fill_in "user[email]", with: "test@test.com"
+          fill_in "user[password]", with: "123456789"
+          fill_in "user[password_confirmation]", with: "123456789"
+          click_button "登録する"
+          Capybara.assert_current_path("/login", ignore_query: true)
+        }.to change { User.count }.by(1)
+      end
+
+      it "名前が記載されていること" do
+        visit "users/new"
+          fill_in "user[user_name]", with: ""
+          fill_in "user[email]", with: "test@test.com"
+          fill_in "user[password]", with: "123456789"
+          fill_in "user[password_confirmation]", with: "123456789"
+          click_button "登録する"
+          expect(page).to have_content "ユーザーネームを入力してください"
+      end
+
+      it "メールアドレスが記載されていること" do
+        visit "users/new"
+          fill_in "user[user_name]", with: "テスト太郎"
+          fill_in "user[email]", with: ""
+          fill_in "user[password]", with: "123456789"
+          fill_in "user[password_confirmation]", with: "123456789"
+          click_button "登録する"
+          expect(page).to have_content "メールアドレスを入力してください"
+      end
+
+      it "パスワードとパスワードの確認が一致していること" do
+        visit "users/new"
+          fill_in "user[user_name]", with: "テスト太郎"
+          fill_in "user[email]", with: "test@test.com"
+          fill_in "user[password]", with: "123456789"
+          fill_in "user[password_confirmation]", with: "987654321"
+          click_button "登録する"
+          expect(page).to have_content "パスワード確認とパスワードの入力が一致しません"
+      end
+
+      it "パスワードが3文字以上であること" do
+        visit "users/new"
+          fill_in "user[user_name]", with: "テスト太郎"
+          fill_in "user[email]", with: "test@test.com"
+          fill_in "user[password]", with: "1"
+          fill_in "user[password_confirmation]", with: "1"
+          click_button "登録する"
+          expect(page).to have_content "パスワードは3文字以上で入力してください"
+      end
+
+      it "パスワード確認が記載されていること" do
+        visit "users/new"
+          fill_in "user[user_name]", with: "テスト太郎"
+          fill_in "user[email]", with: "test@test.com"
+          fill_in "user[password]", with: "1"
+          fill_in "user[password_confirmation]", with: ""
+          click_button "登録する"
+          expect(page).to have_content"パスワード確認を入力してください"
+      end
+    end
+  end
+end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -33,6 +33,7 @@ RSpec.describe "Users", type: :system do
           fill_in "user[password]", with: "123456789"
           fill_in "user[password_confirmation]", with: "123456789"
           click_button "登録する"
+          expect(page).to have_content 'ユーザー登録に失敗しました'
           expect(page).to have_content "ユーザーネームを入力してください"
       end
 
@@ -43,6 +44,7 @@ RSpec.describe "Users", type: :system do
           fill_in "user[password]", with: "123456789"
           fill_in "user[password_confirmation]", with: "123456789"
           click_button "登録する"
+          expect(page).to have_content 'ユーザー登録に失敗しました'
           expect(page).to have_content "メールアドレスを入力してください"
       end
 
@@ -53,6 +55,7 @@ RSpec.describe "Users", type: :system do
           fill_in "user[password]", with: "123456789"
           fill_in "user[password_confirmation]", with: "987654321"
           click_button "登録する"
+          expect(page).to have_content 'ユーザー登録に失敗しました'
           expect(page).to have_content "パスワード確認とパスワードの入力が一致しません"
       end
 
@@ -63,6 +66,7 @@ RSpec.describe "Users", type: :system do
           fill_in "user[password]", with: "1"
           fill_in "user[password_confirmation]", with: "1"
           click_button "登録する"
+          expect(page).to have_content 'ユーザー登録に失敗しました'
           expect(page).to have_content "パスワードは3文字以上で入力してください"
       end
 
@@ -73,7 +77,32 @@ RSpec.describe "Users", type: :system do
           fill_in "user[password]", with: "1"
           fill_in "user[password_confirmation]", with: ""
           click_button "登録する"
+          expect(page).to have_content 'ユーザー登録に失敗しました'
           expect(page).to have_content"パスワード確認を入力してください"
+      end
+
+      it '登録済みのメールアドレスの場合、新規で登録できないこと' do
+        existed_user = create(:user)
+        visit '/users/new'
+        fill_in "user[user_name]", with: "テスト太郎"
+        fill_in "user[email]", with: existed_user.email
+        fill_in "user[password]", with: 'password'
+        fill_in "user[password_confirmation]", with: 'password'
+        click_button "登録する"
+        expect(page).to have_content 'ユーザー登録に失敗しました'
+        expect(page).to have_content 'メールアドレスはすでに存在します'
+      end
+
+      it '登録済みの名前の場合、新規で登録できないこと' do
+        existed_user = create(:user)
+        visit '/users/new'
+        fill_in "user[user_name]", with: "シュクメルリ君"
+        fill_in "user[email]", with: "test@test.com"
+        fill_in "user[password]", with: 'password'
+        fill_in "user[password_confirmation]", with: 'password'
+        click_button "登録する"
+        expect(page).to have_content 'ユーザー登録に失敗しました'
+        expect(page).to have_content 'ユーザーネームはすでに存在します'
       end
     end
   end

--- a/spec/system/users_spec.rb
+++ b/spec/system/users_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 RSpec.describe "Users", type: :system do
-  
   describe "ログイン前" do
-
     context '入力情報異常系' do
       it 'ユーザーが新規作成できないこと' do
         visit '/users/new'
@@ -16,7 +14,7 @@ RSpec.describe "Users", type: :system do
     context "ユーザー登録" do
       it "フォームの入力値が正常の場合登録できること" do
         visit "users/new"
-        expect{
+        expect {
           fill_in "user[user_name]", with: "テスト太郎"
           fill_in "user[email]", with: "test@test.com"
           fill_in "user[password]", with: "123456789"
@@ -78,7 +76,7 @@ RSpec.describe "Users", type: :system do
           fill_in "user[password_confirmation]", with: ""
           click_button "登録する"
           expect(page).to have_content 'ユーザー登録に失敗しました'
-          expect(page).to have_content"パスワード確認を入力してください"
+          expect(page).to have_content "パスワード確認を入力してください"
       end
 
       it '登録済みのメールアドレスの場合、新規で登録できないこと' do


### PR DESCRIPTION
# Gemのwebdriversをインストールする
Gemfileに下記を記載し、インストールする

Gemfile
```Ruby
gem "webdrivers"
```
```
bundle install
```
###  WebDriver
ブラウザを横断的なテストの自動化を実現するためのオープンソースツール
このドライバはウェブページの遷移、インプット項目への入力、JavaScriptの実行などの機能を提供する

# formatの設定
rspecコマンドを使って表示される形式のフォーマットを見やすく設定する
.rspecファイルに下記コードを記載する
```
--format documentation
```
# webdriverの設定
system specでテストを動かすブラウザの設定する
今回はDockerで準備しているものを指定

spec/rails_helper.rbファイル
```Ruby
# capybara等ファイルの読み込み設定
Dir[Rails.root.join('spec', 'support', '**', '*.rb')].sort.each { |f| require f }
...

RSpec.configure do |config|
...
  # ここから
  config.before(:each, type: :system) do
    driven_by :remote_chrome
    Capybara.server_host = IPSocket.getaddress(Socket.gethostname)
    Capybara.server_port = 4444
    Capybara.app_host = "http://#{Capybara.server_host}:#{Capybara.server_port}"
    Capybara.ignore_hidden_elements = false
  end
  # ここまで
end
```
spec/support/capybara.rbファイル
capybaraの設定を記載する
```Ruby
Capybara.register_driver :remote_chrome do |app|
  options = Selenium::WebDriver::Chrome::Options.new
  options.add_argument('no-sandbox')
  options.add_argument('headless')
  options.add_argument('disable-gpu')
  options.add_argument('window-size=1680,1050')
  Capybara::Selenium::Driver.new(app, browser: :remote, url: ENV['SELENIUM_DRIVER_URL'], capabilities: options)
end
```
# スペックフォルダにシステムスペック専用のディレクトリを追加する
```
mkdir spec/system
```
# ユーザー新規登録のシステムスペックファイルを生成
下記のコマンドで生成する
```
docker compose exec web bundle exec rails generate rspec:system User
```
# ユーザー新規登録のシステムスペックファイルを編集
下記のように編集する
```Ruby
require 'rails_helper'
RSpec.describe "Users", type: :system do
  describe "ログイン前" do
    context '入力情報異常系' do
      it 'ユーザーが新規作成できないこと' do
        visit '/users/new'
        expect {
          fill_in "user[email]", with: 'example@example.com'
          click_button "登録する"
        }.to change { User.count }.by(0)
      end
    end

    context "ユーザー登録" do
      it "フォームの入力値が正常の場合登録できること" do
        visit "users/new"
        expect {
          fill_in "user[user_name]", with: "テスト太郎"
          fill_in "user[email]", with: "test@test.com"
          fill_in "user[password]", with: "123456789"
          fill_in "user[password_confirmation]", with: "123456789"
          click_button "登録する"
          Capybara.assert_current_path("/login", ignore_query: true)
        }.to change { User.count }.by(1)
      end

      it "名前が記載されていること" do
        visit "users/new"
          fill_in "user[user_name]", with: ""
          fill_in "user[email]", with: "test@test.com"
          fill_in "user[password]", with: "123456789"
          fill_in "user[password_confirmation]", with: "123456789"
          click_button "登録する"
          expect(page).to have_content 'ユーザー登録に失敗しました'
          expect(page).to have_content "ユーザーネームを入力してください"
      end

      it "メールアドレスが記載されていること" do
        visit "users/new"
          fill_in "user[user_name]", with: "テスト太郎"
          fill_in "user[email]", with: ""
          fill_in "user[password]", with: "123456789"
          fill_in "user[password_confirmation]", with: "123456789"
          click_button "登録する"
          expect(page).to have_content 'ユーザー登録に失敗しました'
          expect(page).to have_content "メールアドレスを入力してください"
      end

      it "パスワードとパスワードの確認が一致していること" do
        visit "users/new"
          fill_in "user[user_name]", with: "テスト太郎"
          fill_in "user[email]", with: "test@test.com"
          fill_in "user[password]", with: "123456789"
          fill_in "user[password_confirmation]", with: "987654321"
          click_button "登録する"
          expect(page).to have_content 'ユーザー登録に失敗しました'
          expect(page).to have_content "パスワード確認とパスワードの入力が一致しません"
      end

      it "パスワードが3文字以上であること" do
        visit "users/new"
          fill_in "user[user_name]", with: "テスト太郎"
          fill_in "user[email]", with: "test@test.com"
          fill_in "user[password]", with: "1"
          fill_in "user[password_confirmation]", with: "1"
          click_button "登録する"
          expect(page).to have_content 'ユーザー登録に失敗しました'
          expect(page).to have_content "パスワードは3文字以上で入力してください"
      end

      it "パスワード確認が記載されていること" do
        visit "users/new"
          fill_in "user[user_name]", with: "テスト太郎"
          fill_in "user[email]", with: "test@test.com"
          fill_in "user[password]", with: "1"
          fill_in "user[password_confirmation]", with: ""
          click_button "登録する"
          expect(page).to have_content 'ユーザー登録に失敗しました'
          expect(page).to have_content "パスワード確認を入力してください"
      end

      it '登録済みのメールアドレスの場合、新規で登録できないこと' do
        existed_user = create(:user)
        visit '/users/new'
        fill_in "user[user_name]", with: "テスト太郎"
        fill_in "user[email]", with: existed_user.email
        fill_in "user[password]", with: 'password'
        fill_in "user[password_confirmation]", with: 'password'
        click_button "登録する"
        expect(page).to have_content 'ユーザー登録に失敗しました'
        expect(page).to have_content 'メールアドレスはすでに存在します'
      end

      it '登録済みの名前の場合、新規で登録できないこと' do
        existed_user = create(:user)
        visit '/users/new'
        fill_in "user[user_name]", with: "シュクメルリ君"
        fill_in "user[email]", with: "test@test.com"
        fill_in "user[password]", with: 'password'
        fill_in "user[password_confirmation]", with: 'password'
        click_button "登録する"
        expect(page).to have_content 'ユーザー登録に失敗しました'
        expect(page).to have_content 'ユーザーネームはすでに存在します'
      end
    end
  end
end
```