### PR TITLE
Rating view

### DIFF
--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -25,23 +25,22 @@
           <td><%= render "favorites/favorite", post: post %></td>
           <!-- 5つ星を評価を設置 -->
           <div data-raty></div>
-          <script src="https://cdn.jsdelivr.net/npm/raty-js@4.3.0/build/raty.min.js"></script>
-            <script>
-            data-raty.empty();
-            if (true) {
-             let indexopt = {
-              document.querySelector('[data-raty]').innerHTML = '';
-              starOn: "<%= asset_path('star-on.png') %>",
-              starOff: "<%= asset_path('star-off.png') %>",
-              starHalf: "<%= asset_path('star-half.png') %>",
-              scoreName: 'post[star]',
-              score: "<%= post.star %>",
-              readOnly: true
-             };
-             const raty = new Raty(document.querySelector('[data-raty]'),indexopt);
-             raty.init();
-             }
-            </script>
+             <script src="https://cdn.jsdelivr.net/npm/raty-js@4.3.0/build/raty.min.js"></script>
+              <script>
+              if (true) {
+               document.querySelector('[data-raty]').innerHTML = '';
+               let showOpt = {
+                starOn: "<%= asset_path('star-on.png') %>",
+                starOff: "<%= asset_path('star-off.png') %>",
+                starHalf: "<%= asset_path('star-half.png') %>",
+                scoreName: 'post[star]',
+                score: "<%= post.star %>",
+                readOnly: true
+               };
+               const raty = new Raty(document.querySelector('[data-raty]'),showOpt);
+               raty.init();
+              }
+              </script>
             <link href="https://cdn.jsdelivr.net/npm/raty-js@4.3.0/src/raty.min.css" rel="stylesheet">
         </ul>
       </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -23,25 +23,6 @@
           <li><i class="bi bi-person"></i><%= post.user.decorate.full_name %></li>
           <li><i class="bi bi-calendar"></i><%= l post.created_at, format: :long %></li>
           <td><%= render "favorites/favorite", post: post %></td>
-          <!-- 5つ星を評価を設置 -->
-          <div data-raty></div>
-             <script src="https://cdn.jsdelivr.net/npm/raty-js@4.3.0/build/raty.min.js"></script>
-              <script>
-              if (true) {
-               document.querySelector('[data-raty]').innerHTML = '';
-               let showOpt = {
-                starOn: "<%= asset_path('star-on.png') %>",
-                starOff: "<%= asset_path('star-off.png') %>",
-                starHalf: "<%= asset_path('star-half.png') %>",
-                scoreName: 'post[star]',
-                score: "<%= post.star %>",
-                readOnly: true
-               };
-               const raty = new Raty(document.querySelector('[data-raty]'),showOpt);
-               raty.init();
-              }
-              </script>
-            <link href="https://cdn.jsdelivr.net/npm/raty-js@4.3.0/src/raty.min.css" rel="stylesheet">
         </ul>
       </div>
     </div>

--- a/app/views/posts/_post.html.erb
+++ b/app/views/posts/_post.html.erb
@@ -24,6 +24,25 @@
           <li><i class="bi bi-calendar"></i><%= l post.created_at, format: :long %></li>
           <td><%= render "favorites/favorite", post: post %></td>
           <!-- 5つ星を評価を設置 -->
+          <div data-raty></div>
+          <script src="https://cdn.jsdelivr.net/npm/raty-js@4.3.0/build/raty.min.js"></script>
+            <script>
+            data-raty.empty();
+            if (true) {
+             let indexopt = {
+              document.querySelector('[data-raty]').innerHTML = '';
+              starOn: "<%= asset_path('star-on.png') %>",
+              starOff: "<%= asset_path('star-off.png') %>",
+              starHalf: "<%= asset_path('star-half.png') %>",
+              scoreName: 'post[star]',
+              score: "<%= post.star %>",
+              readOnly: true
+             };
+             const raty = new Raty(document.querySelector('[data-raty]'),indexopt);
+             raty.init();
+             }
+            </script>
+            <link href="https://cdn.jsdelivr.net/npm/raty-js@4.3.0/src/raty.min.css" rel="stylesheet">
         </ul>
       </div>
     </div>

--- a/app/views/posts/_star.html.erb
+++ b/app/views/posts/_star.html.erb
@@ -3,6 +3,7 @@
           <script src="https://cdn.jsdelivr.net/npm/raty-js@4.3.0/build/raty.min.js"></script>
             <script>
             if (true) {
+             document.querySelector('[data-raty]').innerHTML = '';
              let opt = {
              starOn: "<%= asset_path('star-on.png') %>",
              starOff: "<%= asset_path('star-off.png') %>",

--- a/app/views/posts/show.html.erb
+++ b/app/views/posts/show.html.erb
@@ -33,6 +33,7 @@
              <script src="https://cdn.jsdelivr.net/npm/raty-js@4.3.0/build/raty.min.js"></script>
               <script>
               if (true) {
+               document.querySelector('[data-raty]').innerHTML = '';
                let showOpt = {
                 starOn: "<%= asset_path('star-on.png') %>",
                 starOff: "<%= asset_path('star-off.png') %>",


### PR DESCRIPTION
# 問題
Ratyを利用した星評価を実装中に
ブラウザバックで星評価のある画面に戻ると
星5個が星10個になるという不具合にぶつかった

# 不具合
本来5つ星での評価をしたいのに、
ブラウザバックで評価の存在するページに戻ると
星の数が倍になる
[![Image from Gyazo](https://i.gyazo.com/92d6717aca154bfe53bc089eab7bd528.png)](https://gyazo.com/92d6717aca154bfe53bc089eab7bd528)

正しい表示
[![Image from Gyazo](https://i.gyazo.com/b8df2284ceaa67acb428cdb944580c02.png)](https://gyazo.com/b8df2284ceaa67acb428cdb944580c02)

# 原因
これだと、ページを表示する度に星5つを読み込むことになるが
順序で見てみると

### 1 星5つが読み込まれたページを表示
### 2 ページ移行
### 3 ブラウザバック
### 4 星5つが読み込まれたページ　に　再度星5つ読み込む(合計10個になる)
となる

つまり星10個の時点で他のベー時に移行し、再度ブラウザバックすると星が15個になってしまう

# 対応方法
ページを表示する際に、一度真っさらにさせる

具体的には、Ratyを初期化する前に、data-ratyの中身を空にすることで、以前の星の状態をクリアすることができる
Before
```HTML
<script>
            if (true) {
             let opt = {
             starOn: "<%= asset_path('star-on.png') %>",
             starOff: "<%= asset_path('star-off.png') %>",
```
After
```HTML
<script>
            if (true) {
             document.querySelector('[data-raty]').innerHTML = '';
             let opt = {
             starOn: "<%= asset_path('star-on.png') %>",
             starOff: "<%= asset_path('star-off.png') %>",
```
このようにすることで、ブラウザバックしたときに星が倍になる問題が解決できる
純粋なJavaScriptを使ってinnerHTMLを空にする手法を使い、ページを表示する際に、一度真っさらにさせることができる