### PR TITLE
Correction

### DIFF
--- a/app/views/diagnoses/show.html.erb
+++ b/app/views/diagnoses/show.html.erb
@@ -250,7 +250,7 @@
   </div>
     <div class="diagnosis-inner-text">
       <%= link_to t('diagnoses.botton.diagnosis-again'), new_diagnosis_path, class:"diagnosis-again" %>
-      <%= link_to t('diagnoses.botton.registration'), new_user_path, class:"orange" %>
+      <%= link_to t('diagnoses.botton.registration'), new_user_path, class:"blue" %>
       <div class="overview">
        <div class = "kaisei-decol-regular">
        <br>
@@ -268,6 +268,10 @@
             Xでシェア
             </a>
             <script async src="https://platform.twitter.com/widgets.js" charset="utf-8"></script>
+      </div>
+      <br>
+      <div class="overview">
+       <%= link_to 'トップページに戻る', top_path, class: 'orange' %>
       </div>
     </div>
 </div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -19,7 +19,15 @@
     <% if logged_in? %>
       <!-- ログイン後のコンテンツ -->
       <div class = "kaisei-decol-regular">
-      <h4>クリックして、コメントや投稿をしてみよう</h4>
+       <h4>投稿前に、もう一回診断してみる？</h4>
+      </div>
+      <!-- 診断スタートボタン -->
+      <div class="start-button-container">
+         <%= link_to '診断スタート', new_diagnosis_path, class: 'orange' %>
+      </div>
+      <br>
+      <div class = "kaisei-decol-regular">
+       <h4>クリックして、コメントや投稿をしてみよう</h4>
       </div>
     </div>
       <div class="food-container">

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -120,7 +120,7 @@ ja:
     show:
       title: 評価の詳細とみんなの反応
     index:
-      title: みんなの評価
+      title: みんなの口コミ
       no_result: 投稿がありません
     edit:
       title: 料理の評価を修正


### PR DESCRIPTION
# ログイン後も診断機能をつける

### 理由
・MVPリリース時に幾人かがXにてシェアしているのを確認し、ユーザーに興味を示しているとみて取れたから
・ログイン後に、おすすめのレシピをもう一度確認してみたいという欲求に答えたいから
Before
[![Image from Gyazo](https://i.gyazo.com/f6dc01d1eeda8ee3fa5d8a31abe94a6f.jpg)](https://gyazo.com/f6dc01d1eeda8ee3fa5d8a31abe94a6f)
After
[![Image from Gyazo](https://i.gyazo.com/84fd6278c09b88895f4b51fc8e110f4c.png)](https://gyazo.com/84fd6278c09b88895f4b51fc8e110f4c)

※ログイン前に口コミ一覧と詳細が見れるのも検討したものの、口コミ見て口コミ投稿やめてしまう可能性もあるので、保留にした ログイン時のワクワク感を作りたいため

# 診断結果のフォームにおけるユーザー登録ボタンをオレンジ色から青色に変更

# 口コミ一覧の動的タイトルを下記のように修正
Before
```yml
 index:
      title: みんなの評価
```
After
```yml
 index:
      title: みんなの口コミ
```