### PR TITLE
Translate test

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -7,10 +7,26 @@ class ApplicationController < ActionController::Base
   before_action :require_login
   # require_login は、gem 'sorcery' が提供するメソッドの一つで、ユーザーがログインしているかどうかを判定
   # ログインしていない場合は、not_authenticated メソッドで指定されたパスにリダイレクト
+
+  # before_action は、アクションが実行される前に指定されたメソッドを呼び出す
+  # application_controller.rb に記述することで、ApplicationController クラスを継承しているすべてのコントローラで
+  # before_action が適用される
+  before_action :set_locale
+  # set_localeは各リクエストの冒頭にロケールを設定して、リクエストが持続する間はすべての文字列が指定のロケールで翻訳されるようにする
+  # ロケールはApplicationControllerのbefore_actionで設定できる
+  
   add_flash_types :success, :danger
   # フラッシュメッセージのタイプを追加するメソッド
   # デフォルトでは、notice と alert の二種類のキーしか用意されていないので、
   # 今回は、成功・失敗した際のメッセージに適用されるキーを追加するために、success と danger という2つのキーを追加
+
+  def default_url_options
+    { locale: I18n.locale }
+  end
+  # 上のようにすることで、url_forに依存するすべてのヘルパーメソッド (root_pathやroot_urlなどの名前付きメソッドや
+  # books_pathやbooks_urlなどのリソースルーティングを持つヘルパー) では自動的にロケール情報がクエリ文字列に含まれるようになる 
+  # たとえばhttp://localhost:3001/?locale=jaのような形式になる
+
   private
 
   # not_authenticated メソッドも gem 'sorcery' が提供するもので、ログインしていない場合に指定されたパスにリダイレクト
@@ -20,4 +36,14 @@ class ApplicationController < ActionController::Base
     # デフォルトのリダイレクト先を root_path から login_path に変更
     # defaults.flash_message.require_login = 未ログイン時にログインページにリダイレクトさせた際に表示されるフラッシューメッセージを設定
   end
+
+  def set_locale
+    I18n.locale = params[:locale] || I18n.default_locale
+  end
+  # リクエスト間でロケールを管理する
+  # I18n.localeを明示的に設定しない限り、すべての訳文でデフォルトのロケールが使われる
+  # ローカライズされたアプリケーションは、将来複数ロケールのサポートが必要 
+  # これを行うためには、各リクエストの冒頭にロケールを設定して、
+  # リクエストが持続する間はすべての文字列が指定のロケールで翻訳されるようにしておくべき
+  # ロケールはApplicationControllerのbefore_actionで設定できる
 end

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -14,7 +14,7 @@ class ApplicationController < ActionController::Base
   before_action :set_locale
   # set_localeは各リクエストの冒頭にロケールを設定して、リクエストが持続する間はすべての文字列が指定のロケールで翻訳されるようにする
   # ロケールはApplicationControllerのbefore_actionで設定できる
-  
+
   add_flash_types :success, :danger
   # フラッシュメッセージのタイプを追加するメソッド
   # デフォルトでは、notice と alert の二種類のキーしか用意されていないので、
@@ -24,7 +24,7 @@ class ApplicationController < ActionController::Base
     { locale: I18n.locale }
   end
   # 上のようにすることで、url_forに依存するすべてのヘルパーメソッド (root_pathやroot_urlなどの名前付きメソッドや
-  # books_pathやbooks_urlなどのリソースルーティングを持つヘルパー) では自動的にロケール情報がクエリ文字列に含まれるようになる 
+  # books_pathやbooks_urlなどのリソースルーティングを持つヘルパー) では自動的にロケール情報がクエリ文字列に含まれるようになる
   # たとえばhttp://localhost:3001/?locale=jaのような形式になる
 
   private
@@ -42,7 +42,7 @@ class ApplicationController < ActionController::Base
   end
   # リクエスト間でロケールを管理する
   # I18n.localeを明示的に設定しない限り、すべての訳文でデフォルトのロケールが使われる
-  # ローカライズされたアプリケーションは、将来複数ロケールのサポートが必要 
+  # ローカライズされたアプリケーションは、将来複数ロケールのサポートが必要
   # これを行うためには、各リクエストの冒頭にロケールを設定して、
   # リクエストが持続する間はすべての文字列が指定のロケールで翻訳されるようにしておくべき
   # ロケールはApplicationControllerのbefore_actionで設定できる

--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -5,14 +5,14 @@ class PostsController < ApplicationController
 
     # 料理に応じた情報をハッシュで定義
     recipes = {
-      "ojakhuri" => { name: "オジャフリ", name2: "ოჯახური", image: "Answer01.webp", description: I18n.t("diagnoses.description.ojakhuri3") },
-      "badrijani" => { name: "パドリジャーニ", name2: "ბადრიჯანი", image: "Answer02.webp", description: I18n.t("diagnoses.description.badrijani2") },
-      "sokos" => { name: "ソコスチャシュシュリ", name2: "სოკოს ჭაშუშული", image: "Answer03.webp", description: I18n.t("diagnoses.description.sokos_chashushuli2") },
-      "pkhali" => { name: "プパリ", name2: "ფხალი", image: "Answer04.webp", description: I18n.t("diagnoses.description.pkhali5") },
-      "ostri" => { name: "オーストリ", name2: "ოსტრი", image: "Answer05.webp", description: I18n.t("diagnoses.description.ostri2") },
-      "chikirtma" => { name: "チヒルトゥマ", name2: "ჩიხირთმა", image: "Answer06.webp", description: I18n.t("diagnoses.description.chikirtma3") },
-      "shkmeruli" => { name: "シュクメルリ", name2: "შქმერული", image: "Answer07.webp", description: I18n.t("diagnoses.description.shkmeruli4") },
-      "chakhohbili" => { name: "チャホフビリ", name2: "ჩახოხბილი", image: "Answer08.webp", description: I18n.t("diagnoses.description.chakhohbili2") }
+      "ojakhuri" => { name: I18n.t("diagnoses.description.ojakhuri"), name2: "ოჯახური", image: "Answer01.webp", description: I18n.t("diagnoses.description.ojakhuri3") },
+      "badrijani" => { name: I18n.t("diagnoses.description.badrijani"), name2: "ბადრიჯანი", image: "Answer02.webp", description: I18n.t("diagnoses.description.badrijani2") },
+      "sokos" => { name: I18n.t("diagnoses.description.sokos_chashushuli"), name2: "სოკოს ჭაშუშული", image: "Answer03.webp", description: I18n.t("diagnoses.description.sokos_chashushuli2") },
+      "pkhali" => { name: I18n.t("diagnoses.description.pkhali"), name2: "ფხალი", image: "Answer04.webp", description: I18n.t("diagnoses.description.pkhali5") },
+      "ostri" => { name: I18n.t("diagnoses.description.ostri"), name2: "ოსტრი", image: "Answer05.webp", description: I18n.t("diagnoses.description.ostri2") },
+      "chikirtma" => { name: I18n.t("diagnoses.description.chikirtma"), name2: "ჩიხირთმა", image: "Answer06.webp", description: I18n.t("diagnoses.description.chikirtma3") },
+      "shkmeruli" => { name: I18n.t("diagnoses.description.shkmeruli"), name2: "შქმერული", image: "Answer07.webp", description: I18n.t("diagnoses.description.shkmeruli4") },
+      "chakhohbili" => { name: I18n.t("diagnoses.description.chakhohbili"), name2: "ჩახოხბილი", image: "Answer08.webp", description: I18n.t("diagnoses.description.chakhohbili2") }
     }
 
 

--- a/app/views/diagnoses/new.html.erb
+++ b/app/views/diagnoses/new.html.erb
@@ -8,11 +8,11 @@
   <div class="top-wrapper">
       <div class="top-inner-text">
        <div class = "kaisei-decol-regular">
-        <h2>3つの質問にYESかNOで答えてね</h2>
+        <h2><%= t('diagnoses.question') %></h2>
        </div>
       </div>
           <div class="diagnosis-inner-text">
-              <p>Question1. お酒はよく飲む</p>         
+              <p><%= t('diagnoses.question1') %></p>         
               <%= f.radio_button :question1, "1", id: "question1_yes", class: "hidden-radio" %>
               <label for="question1_yes" class="button yes-button">YES</label>       
               <%= f.radio_button :question1, "2", id: "question1_no", class: "hidden-radio" %>
@@ -20,7 +20,7 @@
           </div>
 
           <div class="diagnosis-inner-text">
-              <p>Question2. 時間がないので、手軽に作りたい</p>
+              <p><%= t('diagnoses.question2') %></p>
               <%= f.radio_button :question2, "1", id: "question2_yes", class: "hidden-radio" %>
               <label for="question2_yes" class="button yes-button">YES</label>
               <%= f.radio_button :question2, "2", id: "question2_no", class: "hidden-radio" %>
@@ -28,7 +28,7 @@
           </div>
 
           <div class="diagnosis-inner-text">
-              <p>Question3. がっつりしたのが食べたい</p>         
+              <p><%= t('diagnoses.question3') %></p>         
               <%= f.radio_button :question3, "1", id: "question3_yes", class: "hidden-radio" %>
               <label for="question3_yes" class="button yes-button">YES</label>    
               <%= f.radio_button :question3, "2", id: "question3_no", class: "hidden-radio" %>

--- a/app/views/diagnoses/show.html.erb
+++ b/app/views/diagnoses/show.html.erb
@@ -20,14 +20,14 @@
       <div class="image-container">
         <%= image_tag 'Answer01.webp', alt: 'オジャフリ', class: 'answer-image' %>
         <div class="text-overlay">
-          <h6>オジャフリ</h6>
+          <h6><%= t('diagnoses.description.ojakhuri') %></h6>
           <div class = "noto-serif-georgian-uniquifier">
           <p>ოჯახური</p>
           </div>
         </div>
       </div>
       <div class="diagnosis-inner-text">
-      <p>概説</p>
+      <p><%= t('diagnoses.overview') %></p>
       </div>
       <div class="overview">
        <div class = "kaisei-decol-regular">
@@ -49,14 +49,14 @@
       <div class="image-container">
         <%= image_tag 'Answer02.webp', alt: 'パドリジャーニ', class: 'answer-image' %>
         <div class="text-overlay">
-          <h6>パドリジャーニ</h6>
+          <h6><%= t('diagnoses.description.badrijani') %></h6>
           <div class = "noto-serif-georgian-uniquifier">
           <p>ბადრიჯანი</p>
           </div>
         </div>
       </div>
       <div class="diagnosis-inner-text">
-      <p>概説</p>
+      <p><%= t('diagnoses.overview') %></p>
       </div>
       <div class="overview">
        <div class = "kaisei-decol-regular">
@@ -78,14 +78,14 @@
       <div class="image-container">
         <%= image_tag 'Answer03.webp', alt: 'ソコスチャシュシュリ', class: 'answer-image' %>
         <div class="text-overlay">
-          <h6>ソコスチャシュシュリ</h6>
+          <h6><%= t('diagnoses.description.sokos_chashushuli') %></h6>
           <div class = "noto-serif-georgian-uniquifier">
            <p>სოკოს ჭაშუშული</p>
           </div>
         </div>
       </div>
       <div class="diagnosis-inner-text">
-      <p>概説</p>
+      <p><%= t('diagnoses.overview') %></p>
       </div>
       <div class="overview">
        <div class = "kaisei-decol-regular">
@@ -106,7 +106,7 @@
       <div class="image-container">
         <%= image_tag 'Answer04.webp', alt: 'プパリ', class: 'answer-image' %>
         <div class="text-overlay">
-          <h6>プパリ</h6>
+          <h6><%= t('diagnoses.description.pkhali') %></h6>
           <div class = "noto-serif-georgian-uniquifier">
            <p>ფხალი</p>
           </div>
@@ -136,14 +136,14 @@
       <div class="image-container">
         <%= image_tag 'Answer05.webp', alt: 'オーストリ', class: 'answer-image' %>
         <div class="text-overlay">
-          <h6>オーストリ</h6>
+          <h6><%= t('diagnoses.description.ostri') %></h6>
           <div class = "noto-serif-georgian-uniquifier">
            <p>ოსტრი</p>
           </div>
         </div>
       </div>
       <div class="diagnosis-inner-text">
-      <p>概説</p>
+      <p><%= t('diagnoses.overview') %></p>
       </div>
       <div class="overview">
        <div class = "kaisei-decol-regular">
@@ -165,14 +165,14 @@
       <div class="image-container">
         <%= image_tag 'Answer06.webp', alt: 'チヒルトゥマ', class: 'answer-image' %>
         <div class="text-overlay">
-          <h6>チヒルトゥマ</h6>
+          <h6><%= t('diagnoses.description.chikirtma') %></h6>
           <div class = "noto-serif-georgian-uniquifier">
            <p>ჩიხირთმა</p>
           </div>
         </div>
       </div>
       <div class="diagnosis-inner-text">
-      <p>概説</p>
+      <p><%= t('diagnoses.overview') %></p>
       </div>
       <div class="overview">
        <div class = "kaisei-decol-regular">
@@ -194,14 +194,14 @@
       <div class="image-container">
         <%= image_tag 'Answer07.webp', alt: 'シュクメルリ', class: 'answer-image' %>
         <div class="text-overlay">
-          <h6>シュクメルリ</h6>
+          <h6><%= t('diagnoses.description.shkmeruli') %></h6>
           <div class = "noto-serif-georgian-uniquifier">
            <p>შქმერული</p>
           </div>
         </div>
       </div>
       <div class="diagnosis-inner-text">
-      <p>概説</p>
+      <p><%= t('diagnoses.overview') %></p>
       </div>
       <div class="overview">
        <div class = "kaisei-decol-regular">
@@ -224,14 +224,14 @@
       <div class="image-container">
         <%= image_tag 'Answer08.webp', alt: 'チャホフビリ', class: 'answer-image' %>
         <div class="text-overlay">
-          <h6>チャホフビリ</h6>
+          <h6><%= t('diagnoses.description.chakhohbili') %></h6>
           <div class = "noto-serif-georgian-uniquifier">
            <p>ჩახოხბილი</p>
           </div>
         </div>
       </div>
       <div class="diagnosis-inner-text">
-      <p>概説</p>
+      <p><%= t('diagnoses.overview') %></p>
       </div>
       <div class="overview">
        <div class = "kaisei-decol-regular">
@@ -254,7 +254,7 @@
       <div class="overview">
        <div class = "kaisei-decol-regular">
        <br>
-       <p>Xのシェアはこちら</p>
+       <p><p><%= t('diagnoses.Click here to share') %></p></p>
        </div>
       </div>
       <div class="share-buttons">
@@ -271,7 +271,7 @@
       </div>
       <br>
       <div class="overview">
-       <%= link_to 'トップページに戻る', top_path, class: 'orange' %>
+       <%= link_to t('static_pages.return_button'), top_path, class: 'orange' %>
       </div>
     </div>
 </div>

--- a/app/views/posts/_form.html.erb
+++ b/app/views/posts/_form.html.erb
@@ -18,7 +18,7 @@
     </div>
     <!-- 評価表示部位 -->
     <div class="mb-3">
-      <%= f.label "評価" %>
+      <%= f.label :rating %>
       <%= @post.star %>
       <%= render 'star', post: @post %>
     </div>

--- a/app/views/posts/index.html.erb
+++ b/app/views/posts/index.html.erb
@@ -18,13 +18,13 @@
       <%= image_tag @recipe_info[:image], class: "post-food-image" %>
   </div>
       <div class="overview">
-      <p>概説</p>
+      <p><%= t('diagnoses.overview') %></p>
        <div class = "kaisei-decol-regular">
         <p><%= @recipe_info[:description] %></p>
        </div>
        <!-- 5つ星を評価を設置 -->
         <div class = "kaisei-decol-regular">
-         <p>口コミレビュー</p>
+         <p><%= t('diagnoses.review') %></p>
         </div>
           <div data-raty data-score="<%= @average_star %>"></div>
           <p><span class="average-score-text"><%= @average_star.round(1) %></span> / 5.0</p>
@@ -68,6 +68,8 @@
      <!-- new アクションで投稿を作成する際、どの料理に対する投稿かを渡す必要がある -->
      <!--  例えば、new アクションのリンクに recipe パラメータを追加し、新規投稿画面にそれを渡す-->
      <%= link_to t('posts.new.title'), new_post_path(recipe: @recipe), class: "blue" %>
+     <br>
+     <%= link_to t('static_pages.return_button'), top_path, class: 'orange' %>
      </div>
    </div>
   </div>

--- a/app/views/posts/new.html.erb
+++ b/app/views/posts/new.html.erb
@@ -5,7 +5,7 @@
         <div class="col-lg-8 offset-lg-2">
               <div class="top-inner-text">
                 <h1><%= t('.title') %></h1>
-                <h2>他のユーザーの参考になるように、感想を共有してみよう</h2>
+                <h2><%= t('.subtitle') %></h2>
               </div>
             <%= form_with model: @post, url: posts_path(recipe: params[:recipe]), html: { multipart: true }, class: "new_post" do |f| %>
                 <%= hidden_field_tag :recipe, params[:recipe] %>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -7,8 +7,7 @@
       aria-controls='navbarSupportedContent' aria-expanded='false' aria-label='Toggle navigation'>
       <span class='navbar-toggler-icon'></span>
     </button>
-    <%= link_to 'JP', url_for(locale: :ja), class: "text-white text-xs py-2 px-2" %> /
-    <%= link_to 'EN', url_for(locale: :en), class: "text-white text-xs py-2 px-2" %>
+    
 
     <div class='collapse navbar-collapse' id='navbarSupportedContent'>
       <ul class='navbar-nav ms-auto main-nav align-items-center'>
@@ -19,6 +18,8 @@
         <li class='nav-item'>
           <%= link_to t('header.new'), new_user_path, class: 'nav-link' %>
         </li>
+        <%= link_to 'JP', url_for(locale: :ja), class: "text-white text-xs py-2 px-2" %> /
+        <%= link_to 'EN', url_for(locale: :en), class: "text-white text-xs py-2 px-2" %>
       </ul>
     </div>
   </nav>

--- a/app/views/shared/_before_login_header.html.erb
+++ b/app/views/shared/_before_login_header.html.erb
@@ -7,6 +7,8 @@
       aria-controls='navbarSupportedContent' aria-expanded='false' aria-label='Toggle navigation'>
       <span class='navbar-toggler-icon'></span>
     </button>
+    <%= link_to 'JP', url_for(locale: :ja), class: "text-white text-xs py-2 px-2" %> /
+    <%= link_to 'EN', url_for(locale: :en), class: "text-white text-xs py-2 px-2" %>
 
     <div class='collapse navbar-collapse' id='navbarSupportedContent'>
       <ul class='navbar-nav ms-auto main-nav align-items-center'>

--- a/app/views/shared/_header.html.erb
+++ b/app/views/shared/_header.html.erb
@@ -7,6 +7,7 @@
       aria-controls='navbarSupportedContent' aria-expanded='false' aria-label='Toggle navigation'>
       <span class='navbar-toggler-icon'></span>
     </button>
+    
 
     <div class='collapse navbar-collapse' id='navbarSupportedContent'>
       <ul class='navbar-nav ms-auto main-nav align-items-center'>
@@ -30,6 +31,8 @@
             <li class='nav-item'><%= link_to '「参考になった」投稿', favorites_posts_path, class: 'nav-link' %></li>
             <!-- ユーザー自身が投稿したものをヘッダーの「投稿一覧」にアクセスした際に確認できるように実装 -->
             <li class='nav-item'><%= link_to '投稿一覧', posts_posts_path, class: 'nav-link' %></li>
+            <%= link_to 'JP', url_for(locale: :ja), class: "text-white text-xs py-2 px-2" %> /
+            <%= link_to 'EN', url_for(locale: :en), class: "text-white text-xs py-2 px-2" %>
            </div>
           </ul>
         </li>

--- a/app/views/static_pages/food.html.erb
+++ b/app/views/static_pages/food.html.erb
@@ -7,34 +7,30 @@
   </div>
     <div class="georgia-deta">
     <div class = "kaisei-decol-regular">
-    <p>ジョージアは古来から数多くの民族が行き交うアジアとヨーロッパを
-    つなぐ交通の要衝であった。</p>
-    <p>歴史上、隣接する国に支配されていたことで
-    料理においても、アジアの要素とヨーロッパの要素を混ぜ合わせた文化が
-    形成し、今に至る</p>
+    <p><%= t('static_pages.Georgian_Food1') %></p>
+    <p><%= t('static_pages.Georgian_Food2') %></p>
     </div>
     </div>
   <div class="georgia-inner-text">
    <div class = "kaisei-decol-regular">
-    <h1>主食は何？</h1>
+    <h1><%= t('static_pages.Georgian_Food3') %></h1>
    </div>
   </div>
   <div class="georgia-deta">
     <div class = "kaisei-decol-regular">
-  <p>小麦を使ったパンが主食、各エリアごと山岳に囲まれていることから</p>
-  <p>パン作りの材料、製法がエリアごとで異なる</p>
-  <p>北に隣接するロシアの影響で、ライ麦もよく口にする</p>
+  <p><%= t('static_pages.Georgian_Food4') %></p>
+  <p><%= t('static_pages.Georgian_Food5') %></p>
+  <p><%= t('static_pages.Georgian_Food6') %></p>
   </div>
   </div>
   <div class="georgia-inner-text">
    <div class = "kaisei-decol-regular">
-    <h1>料理の特色は？</h1>
+    <h1<%= t('static_pages.Georgian_Food7') %></h1>
    </div>
   </div>
   <div class="georgia-deta">
     <div class = "kaisei-decol-regular">
-  <p>西アジアの影響でハーブやスパイスを多用する
-  歯ざわりや風味付けにクルミをよく用いる</p>
+  <p><%= t('static_pages.Georgian_Food8') %></p>
   </div>
   </div>
   <!-- 画像 -->
@@ -44,6 +40,6 @@
        </div>
   <br>
   <div class="overview">
-    <%= link_to 'トップページに戻る', top_path, class: 'orange' %>
+    <%= link_to t('static_pages.return_button'), top_path, class: 'orange' %>
   </div>
 </div>

--- a/app/views/static_pages/georgia.html.erb
+++ b/app/views/static_pages/georgia.html.erb
@@ -8,14 +8,14 @@
   <br>
     <div class="georgia-deta">
      <div class = "kaisei-decol-regular">
-      <p>1. 面積<br>6万9,700平方キロメートル（日本の約5分の1）</p>
-      <p>2. 人口<br>370万人（2023年：国連人口基金）</p>
-      <p>3. 首都<br>トビリシ</p>
-      <p>4. 民族<br>ジョージア系（86.8％）、アゼルバイジャン系（6.2％）、アルメニア系（4.5％）、ロシア系（0.7％）、オセチア系（0.4％）</p>
-      <p>5. 言語<br>公用語はジョージア語（コーカサス諸語に属する）</p>
-      <p>6. 宗教<br>主としてキリスト教（ジョージア正教）</p>
-      <p>7. その他<br>コーカサス山脈の南側、黒海の東岸に位置し、アジアとヨーロッパをつなぐ交通の要衝<br>
-      ワインの原料となるブドウの醸造文化は8000年以上の歴史があり、世界最古ともいわれている。現在もワイン生産が盛ん</p>
+      <p><%= t('static_pages.Georgia1') %><br><%= t('static_pages.Georgia2') %></p>
+      <p><%= t('static_pages.Georgia3') %><br><%= t('static_pages.Georgia4') %></p>
+      <p><%= t('static_pages.Georgia5') %><br><%= t('static_pages.Georgia6') %></p>
+      <p><%= t('static_pages.Georgia7') %><br><%= t('static_pages.Georgia8') %></p>
+      <p><%= t('static_pages.Georgia9') %><br><%= t('static_pages.Georgia10') %></p>
+      <p><%= t('static_pages.Georgia11') %><br><%= t('static_pages.Georgia12') %></p>
+      <p><%= t('static_pages.Georgia13') %><br><%= t('static_pages.Georgia14') %><br>
+      <%= t('static_pages..Georgia15') %></p>
       <p><%= t('static_pages.reference_materials') %><br>
       <a href="https://www.mofa.go.jp/mofaj/area/georgia/index.html" target="_blank">外務省：ジョージア</a><br>
       <a href="https://www.mofa.go.jp/mofaj/area/georgia/data.html" target="_blank">外務省：ジョージアのデータ</a></p>
@@ -28,6 +28,6 @@
     </div>
     <br>
     <div class="overview">
-    <%= link_to 'トップページに戻る', top_path, class: 'orange' %>
+    <%= link_to t('static_pages.return_button'), top_path, class: 'orange' %>
     </div>
 </div>

--- a/app/views/static_pages/how_to_use.html.erb
+++ b/app/views/static_pages/how_to_use.html.erb
@@ -13,45 +13,45 @@
   <br>
     <div class="overview">
      <div class = "kaisei-decol-regular">
-     <p>「ガマルジョバ」</p>
+     <p><%= t('static_pages.how_to_use1') %></p>
      <div class = "noto-serif-georgian-uniquifier">
        <p>გამარჯობა</p>
      </div>
-     これはジョージア語で「こんにちは」を意味する日常会話です</p>
-     <p>日常会話のようにみんながジョージア料理を共有することを願って、アプリの名前にしました</p>
-     <p>当アプリでは、簡単な診断をYESNO形式で回答後、おすすめのジョージア料理をあなたに提案いたします</p>
+     <%= t('static_pages.how_to_use2') %></p>
+     <p><%= t('static_pages.how_to_use3') %></p>
+     <p><%= t('static_pages.how_to_use4') %></p>
      <a href="https://gyazo.com/9cd7276af41c782bcc3bd63724cd7d9d"><video width="748" autoplay muted loop playsinline><source src="https://i.gyazo.com/9cd7276af41c782bcc3bd63724cd7d9d.mp4" type="video/mp4"/></video></a>
-     <p>診断した結果に応じておすすめのジョージア料理と作り方のページに遷移できます</p>
-     <p>また、Xでのシェア機能を用いて、多くの人に共有できます</p>
+     <p><%= t('static_pages.how_to_use5') %></p>
+     <p><%= t('static_pages.how_to_use6') %></p>
      <a href="https://gyazo.com/020872b963df6db8e7a421851251c9f1"><video width="748" autoplay muted loop playsinline><source src="https://i.gyazo.com/020872b963df6db8e7a421851251c9f1.mp4" type="video/mp4"/></video></a>
      <br>
      <img src="https://i.gyazo.com/1ed020c1c3e22b1317a8cbff3b38e2f5.png" class: 'food-link'>
-     <p>診断はログインの有無関係なく可能です</p>
-     <p>ユーザー登録しログインすると、各料理の掲示板にとびます</p>
-     <p>Google認証によるログインも下記から可能です</p>
+     <p><%= t('static_pages.how_to_use7') %></p>
+     <p><%= t('static_pages.how_to_use8') %></p>
+     <p><%= t('static_pages.how_to_use9') %></p>
           <div class='text-center'>
            <%= link_to auth_at_provider_path(provider: :google), data: { turbo: false } do %>
            <%= image_tag "google_sign_in.png", class: "w-1/2 md:w-3/5 mx-auto py-5" %>
            <% end %>
           </div>
-     <p>ここでは自ら作った物を各料理掲示板の中で口コミをすることができ、</p>
+     <p><%= t('static_pages.how_to_use10') %></p>
      <a href="https://gyazo.com/d8e53ab13039a02ce4751f4243d5c4a3"><video width="748" autoplay muted loop playsinline><source src="https://i.gyazo.com/d8e53ab13039a02ce4751f4243d5c4a3.mp4" type="video/mp4"/></video></a>
      <br>
-     画像アップロードして投稿することもできます</p>
+     <%= t('static_pages.how_to_use11') %></p>
      <a href="https://gyazo.com/82ed38aa4fc0c4a8ab40a6117f87da18"><video width="748" autoplay muted loop playsinline><source src="https://i.gyazo.com/82ed38aa4fc0c4a8ab40a6117f87da18.mp4" type="video/mp4"/></video></a>
      <br>
-     <p>詳細を見るとレビュー評価も確認できます</p>
+     <p><%= t('static_pages.how_to_use12') %></p>
      <a href="https://gyazo.com/773299f3a94dc1fab144c2dfc85277ef"><video width="748" autoplay muted loop playsinline><source src="https://i.gyazo.com/773299f3a94dc1fab144c2dfc85277ef.mp4" type="video/mp4"/></video></a>
      <br>
-     <p>参考になった口コミに関しては、いいねをすることが可能です</p>
+     <p><%= t('static_pages.how_to_use13') %></p>
      <a href="https://gyazo.com/a2e00bfdf0185eb9ef63a0d81f7408ed"><video width="748" autoplay muted loop playsinline><source src="https://i.gyazo.com/a2e00bfdf0185eb9ef63a0d81f7408ed.mp4" type="video/mp4"/></video></a>
      <br>
-     <p>いいねした投稿、ユーザー自身が投稿した口コミはヘッダー上でにアクセスできます</p>
+     <p><%= t('static_pages.how_to_use14') %></p>
      <a href="https://gyazo.com/0a8fc9f2c31c14626613764d857a6114"><video width="748" autoplay muted loop playsinline><source src="https://i.gyazo.com/0a8fc9f2c31c14626613764d857a6114.mp4" type="video/mp4"/></video></a>
      </div>  
     </div>
     <br>
     <div class="overview">
-    <%= link_to 'トップページに戻る', top_path, class: 'orange' %>
+    <%= link_to t('static_pages.return_button'), top_path, class: 'orange' %>
     </div>
 </div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -9,8 +9,8 @@
 <div class="top-wrapper">
   <div class="top-inner-text">
       <div class = "kaisei-decol-regular">
-       <h1>ジョージア料理診断アプリ</h1>
-       <h2>ガマルジョバ</h2> 
+       <h1><%= t('static_pages.title') %></h1>
+       <h2><%= t('static_pages.subtitle') %></h2> 
       </div>
       <div class = "noto-serif-georgian-uniquifier">
       <h3>გამარჯობა</h3>
@@ -127,14 +127,14 @@
     <% else %>
       <!-- ログイン前のコンテンツ -->
       <div class = "kaisei-decol-regular">
-      <h4>診断始める前に、こちらを確認</h4>
+      <h4><%= t('static_pages.check here before starting diagnosis') %></h4>
       </div>
       <div class="button-container">
         <!-- 上部のボタン -->
        <div class="image-container">
         <div class="button upper-button">
          <div class = "kaisei-decol-regular">
-          <%= link_to "このアプリの使い方", how_to_use_path, class: 'button-text'%>
+          <%= link_to t('static_pages.how_to_use_this_app'), how_to_use_path, class: 'button-text'%>
          </div>
         </div>
        </div>
@@ -157,11 +157,11 @@
         <!-- みんなの口コミのボタン -->
       </div>
       <div class = "kaisei-decol-regular">
-       <h5>確認出来たら</h5>
+       <h5><%= t('static_pages.If you can confirm it.') %></h5>
       </div>
       <!-- 診断スタートボタン -->
       <div class="start-button-container">
-        <%= link_to '診断スタート', new_diagnosis_path, class: 'orange' %>
+        <%= link_to t('static_pages.start_button'), new_diagnosis_path, class: 'orange' %>
       </div>
     <% end %>
   </div>

--- a/app/views/static_pages/top.html.erb
+++ b/app/views/static_pages/top.html.erb
@@ -19,15 +19,15 @@
     <% if logged_in? %>
       <!-- ログイン後のコンテンツ -->
       <div class = "kaisei-decol-regular">
-       <h4>投稿前に、もう一回診断してみる？</h4>
+       <h4><%= t('static_pages.another_diagnosis') %></h4>
       </div>
       <!-- 診断スタートボタン -->
       <div class="start-button-container">
-         <%= link_to '診断スタート', new_diagnosis_path, class: 'orange' %>
+         <%= link_to t('static_pages.start_button'), new_diagnosis_path, class: 'orange' %>
       </div>
       <br>
       <div class = "kaisei-decol-regular">
-       <h4>クリックして、コメントや投稿をしてみよう</h4>
+       <h4><%= t('static_pages.click_to_comment_or_post!') %></h4>
       </div>
     </div>
       <div class="food-container">
@@ -38,7 +38,7 @@
             <%= link_to posts_path(recipe: "ojakhuri"), class: 'food-link' do %>
               <%= image_tag('Answer01.webp', class: 'food-image') %>
                <span class="food-text">
-                オジャフリ
+                <%= t('diagnoses.description.ojakhuri') %>
                 <div class = "noto-serif-georgian-uniquifier">
                  <p>ოჯახური</p>
                 </div>
@@ -49,7 +49,7 @@
             <%= link_to posts_path(recipe: "badrijani"), class: 'food-link' do %>
               <%= image_tag('Answer02.webp', class: 'food-image')%>
                <span class="food-text">
-                パドリジャーニ
+                <%= t('diagnoses.description.badrijani') %>
                 <div class = "noto-serif-georgian-uniquifier">
                  <p>ბადრიჯანი</p>
                 </div>
@@ -60,7 +60,7 @@
             <%= link_to posts_path(recipe: "sokos"), class: 'food-link' do %>
               <%= image_tag('Answer03.webp', class: 'food-image')%>
                <span class="food-text">
-                ソコスチャシュシュリ
+                <%= t('diagnoses.description.sokos_chashushuli') %>
                 <div class = "noto-serif-georgian-uniquifier">
                  <p>სოკოს ჭაშუშული</p>
                 </div>
@@ -71,7 +71,7 @@
             <%= link_to posts_path(recipe: "pkhali"), class: 'food-link' do %>
               <%= image_tag('Answer04.webp', class: 'food-image')%>
                <span class="food-text">
-                プパリ
+                <%= t('diagnoses.description.pkhali') %>
                 <div class = "noto-serif-georgian-uniquifier">
                  <p>ფხალი</p>
                 </div>
@@ -82,7 +82,7 @@
             <%= link_to posts_path(recipe: "ostri"), class: 'food-link' do %>
               <%= image_tag('Answer05.webp', class: 'food-image')%>
                <span class="food-text">
-                オーストリ
+                <%= t('diagnoses.description.ostri') %>
                 <div class = "noto-serif-georgian-uniquifier">
                  <p>ოსტრი</p>
                 </div>
@@ -93,7 +93,7 @@
             <%= link_to posts_path(recipe: "chikirtma"), class: 'food-link' do %>
               <%= image_tag('Answer06.webp', class: 'food-image')%>
                <span class="food-text">
-                チヒルトゥマ
+                <%= t('diagnoses.description.chikirtma') %>
                 <div class = "noto-serif-georgian-uniquifier">
                  <p>ჩიხირთმა</p>
                 </div>
@@ -104,7 +104,7 @@
             <%= link_to posts_path(recipe: "shkmeruli"), class: 'food-link' do %>
               <%= image_tag('Answer07.webp', class: 'food-image')%>
                <span class="food-text">
-                シュクメルリ
+                <%= t('diagnoses.description.shkmeruli') %>
                 <div class = "noto-serif-georgian-uniquifier">
                  <p>შქმერული</p>
                 </div>
@@ -115,7 +115,7 @@
             <%= link_to posts_path(recipe: "chakhohbili"), class: 'food-link' do %>
               <%= image_tag('Answer08.webp', class: 'food-image')%>
                <span class="food-text">
-                チャホフビリ
+                <%= t('diagnoses.description.chakhohbili') %>
                 <div class = "noto-serif-georgian-uniquifier">
                  <p>ჩახოხბილი</p>
                 </div>

--- a/app/views/user_sessions/new.html.erb
+++ b/app/views/user_sessions/new.html.erb
@@ -35,7 +35,7 @@
         <br>
         <!-- 「Googleログインの方はこちら」のリンク -->
         <div class='text-center text-sm'>
-          Googleログインの方はこちら
+          <%= t('users.new.google') %>
         </div>
          <div class='text-center'>
           <%= link_to auth_at_provider_path(provider: :google), data: { turbo: false } do %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -3,7 +3,7 @@
  <div class="container">
   <div class="row">
     <div class="col-md-10 col-lg-8 mx-auto">
-      <h1>ユーザー登録</h1>
+      <h1><%= t('users.new.title') %></h1>
       <%= form_with model: @user do |f| %>
         <!-- エラーメッセージの表示 -->
         <%= render 'shared/error_messages', object: @user %>
@@ -23,12 +23,12 @@
           <%= f.label :password_confirmation, class: "form-label" %>
           <%= f.password_field :password_confirmation, class: "form-control custom-input" %>
         </div>
-        <%= f.submit "登録する", class: "btn btn-primary" %>
+        <%= f.submit t('users.new.register'), class: "btn btn-primary" %>
       <% end %>
       <br>
         <!-- 「Googleログインの方はこちら」のリンク -->
         <div class='text-center text-sm'>
-          Googleログインの方はこちら
+          <%= t('users.new.google') %>
         </div>
          <div class='text-center'>
           <%= link_to auth_at_provider_path(provider: :google), data: { turbo: false } do %>

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,6 +44,6 @@ module Myapp
     # Railsアプリケーションのデフォルトの言語設定が日本語（:ja）に設定される
     config.time_zone = "Tokyo"
     # デフォルトのタイムゾーンを日本時間に設定する
-    config.i18n.available_locales = [:ja, :en]
+    config.i18n.available_locales = [ :ja, :en ]
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -44,5 +44,6 @@ module Myapp
     # Railsアプリケーションのデフォルトの言語設定が日本語（:ja）に設定される
     config.time_zone = "Tokyo"
     # デフォルトのタイムゾーンを日本時間に設定する
+    config.i18n.available_locales = [:ja, :en]
   end
 end

--- a/config/locales/activerecord/en.yml
+++ b/config/locales/activerecord/en.yml
@@ -1,0 +1,19 @@
+en:
+  activerecord:
+    models:
+      user: User
+      post: Cooking evaluation
+      comment: Comment
+    attributes:
+      user:
+        email: email
+        user_name: User Name
+        password: Password
+        password_confirmation: Password Confirmation
+      post:
+        title: Title
+        body: Body (of letter)
+        post_image: Upload an image
+        rating: Rating Star
+      comment:
+        body: Comment

--- a/config/locales/activerecord/ja.yml
+++ b/config/locales/activerecord/ja.yml
@@ -14,5 +14,6 @@ ja:
         title: タイトル
         body: 本文
         post_image: 画像をアップロード
+        rating: 評価
       comment:
         body: コメント

--- a/config/locales/view/en.yml
+++ b/config/locales/view/en.yml
@@ -1,0 +1,214 @@
+en:
+  defaults:
+    create: Create
+    post: Post
+    search_word: Search word (search by title or body keywords)
+    delete_confirm: Delete the post?
+    flash_message:
+      created: “%{item} has been created”
+      not_created: “%{item} could not be created”
+      require_login: Please login
+      created: “%{item} has been created”
+      updated: “%{item} has been updated”
+      not_updated: “Could not update %{item}”
+      not_created: “%{item} could not be created”
+      deleted: “%{item} has been deleted”
+    edit: edit
+  helpers:
+    submit: 
+      create: register
+      submit: save
+      update: update
+    label: 
+      email: Email address
+      password: Password
+      title: Title
+      body: Body
+  user_sessions:
+    new:
+      title: login
+      login: login
+      to_register_page: First time user?
+      password_forget: Forgot your password?
+    create:
+      success: You have logged in
+      failure: login failed
+    destroy: 
+      success: Logged out
+  users:
+    new: 
+      title: User registration
+    create:
+      success: User registration completed
+      failure: user registration failed
+      diagnoses_success: diagnoses completed
+      diagnoses_null: no answer selected
+  header:
+    login: login
+    logout: logout
+    new: New registration
+    show: Profile settings
+  password_ressets:
+    new:
+      title: Password reset
+      submit: Submit
+    edit: 
+      title: Edit password
+  notices:
+    login_success: “Login succeeded”.
+    logout_success: “You have logged out”
+  oauths:
+    login_success: “You have signed in with your Google account.
+    login_failure: “Google authentication has failed”
+  alerts:
+    invalid_credentials: “Your email or password is incorrect.”
+  static_pages:
+    title: Georgia Cuisine Diagnostic App
+    subtitle: Gamarjoba
+    check here before starting diagnosis: Check here before starting diagnosis
+    how_to_use_this_app: How to use this app
+    how_to_use1: “Gamarjoba”
+    how_to_use2: This is an everyday conversation meaning “hello” in Georgian
+    how_to_use3: We named the app in the hope that everyone will share Georgian food like in everyday conversation!
+    how_to_use4: After answering a simple yes-no question, the app will recommend a Georgian dish for you!
+    how_to_use5: Depending on the results of the diagnosis, you will be redirected to a page with recommended Georgian dishes and how to cook them.
+    how_to_use6: You can also share your recommendations with as many people as you like by using the share function on X.
+    how_to_use7: Diagnostics can be done with or without login
+    how_to_use8: You can jump to each cuisine's forum after registering and logging in.
+    how_to_use9: You can also login with Google Authentication
+    how_to_use10: Here you can review your own creations in the various forums,
+    how_to_use11: You can also upload and post images
+    how_to_use12: You can also check the review ratings by looking at the details
+    how_to_use13: You can like the reviews that you find helpful
+    how_to_use14: You can access the liked posts and your own reviews on the header
+    What kind of country is Georgia?: What kind of country is Georgia?
+    Georgia1: 1. area
+    Georgia2: 69,700 square kilometers (about one-fifth the size of Japan)
+    Georgia3: 2. population
+    Georgia4: "3.7 million (2023: UN Population Fund)"
+    Georgia5: 3. capital
+    Georgia6: Tbilisi
+    Georgia7: 4. ethnicity
+    Georgia8: Georgian (86.8%), Azerbaijani (6.2%), Armenian (4.5%), Russian (0.7%), Ossetian (0.4%)
+    Georgia9: 5. Languages
+    Georgia10: Official language is Georgian (part of the Caucasian languages)
+    Georgia11: 6. religion
+    Georgia12: Mainly Christian (Georgian Orthodox)
+    Georgia13: 7. other
+    Georgia14: Located on the eastern shore of the Black Sea, south of the Caucasus Mountains, and a major transportation hub between Asia and Europe.
+    Georgia15: The culture of vinification of grapes, the raw material for wine, has a history of more than 8,000 years and is said to be the oldest in the world. Wine production still flourishes today.
+    What is a Georgian_Food?: What is a Georgian_Food
+    Georgian_Food1: Georgia has been a major transportation hub connecting Asia and Europe with many ethnic groups since ancient times.
+    Georgian_Food2: Historically, Georgia has been dominated by neighboring countries, which has led to the development of a culture that mixes Asian and European elements in its cuisine.
+    Georgian_Food3: What is the staple food?
+    Georgian_Food4: Bread made of wheat is the staple food, as each area is surrounded by mountains.
+    Georgian_Food5: Ingredients and methods of bread making differ from area to area.
+    Georgian_Food6: Rye is also commonly consumed due to the influence of Russia, which borders to the north.
+    Georgian_Food7: What are the characteristics of the cuisine?
+    Georgian_Food8: Influenced by West Asia, with a lot of herbs and spices.
+    reference_materials: "reference materials:"
+    If you can confirm it: If you can confirm it.
+    start_button: "Diagnosis Start"
+    return_button: "Return to Top Page"
+    georgia:
+      title: What is a Georgia?
+    food:
+      title: What is a Georgian_Food?
+    how_to_use:
+      title: how_to_use_this_app
+  diagnoses:
+    new:
+      title: Start diagnoses
+    question: Please answer YES or NO to the following three questions.
+    question1: Question1. I drink a lot.
+    question2: Question2. I don't have much time, so I want to make it easy.
+    question3: Question3. I want to eat a hearty meal.
+    show:
+      title: Your recommendation is
+    recommended: recommended here
+    New registration, login: New registration, login
+    lets_post_comments_and_rate_the_dishes!: "lets_post_comments_and_rate_the_dishes!"
+    Click here to share X: Click here to share X
+    overview: Overview
+    description:
+      ojakhuri: Ojakhuri
+      badrijani: Badrijani
+      sokos_chashushuli: Sokos_chashushuli
+      pkhali: Pkhali
+      ostri: Ostri
+      chikirtma: Chikirtma
+      shkmeruli: Shkmeruli
+      chakhohbili: Chakhohbili
+      ojakhuri1: "A typical Georgian meat dish known as “family meal"
+      ojakhuri2: "A “Georgian German potato” made with potatoes, onions, pork and herbs such as garlic and pak choi"
+      ojakhuri3: The crispy potatoes and the crunchy meat are very appetizing and go great with beer!
+      badrijani1: “one of the most typical appetizers of Georgian cuisine with maximum walnut flavor”
+      badrijani2: “The grilled eggplant is rolled in a paste of walnuts, which makes it look great and is a great choice for small parties.”
+      badrijani3: “If you have a food processor or blender, you can easily make walnut paste.
+      sokos_chashushuli1: “Georgian sauteed mushrooms with herbs.”
+      sokos_chashushuli2: “Easy and tasty to make with your favorite mushrooms, sauteed with minimal spices at home.”
+      pkhali1: “One of the appetizers with vegetables and walnuts in a paste.”
+      pkhali2: “Basically spinach, beets, etc. are used in most cases, but any vegetable can be used.”
+      pkhali3: “The different colors of the various vegetables allow you to make different shades of pupali.”
+      pkhali4: “This is why in Georgia they are often prepared at banquets.”
+      pkhali5: “One of the appetizers made of a paste of vegetables and walnuts, eaten with bread.”
+      ostri1: “a stew of veal and tomatoes.”
+      ostri2: “It has a deep spicy flavor because of the abundant use of spices and chili peppers.”
+      ostri3: “In Georgia we eat it with bread, but it also goes well with rice. I recommend it to drinkers because it goes great with alcohol.”
+      chikirtma1: “Chicken and egg soup.”
+      chikirtma2: “It does not require the spices commonly used in Georgia and can easily be made with powdered bouillon or consommé.”
+      chikirtma3: “I recommend this when you are sick or hungover because the lightness of the chicken and the tenderness of the eggs soak into your body.”
+      shkmeruli1: “cream stew with chicken and garlic”
+      shkmeruli2: “You can use chopped garlic, but a garlic tube is also delicious.”
+      shkmeruli3: “The authentic version is made with only chicken and garlic, but you can also add potatoes, onions, and sweet potatoes like in a stew.”
+      shkmeruli4: “Chicken and garlic in cream, for those who like garlic.”
+      chakhohbili1: “Chicken stewed with tomatoes.”
+      chakhohbili2: “It looks spicy, but it uses very little spice, and the combination of the non-habitual savory flavor of the chicken and the umami of the tomatoes is sure to please everyone.”
+      chakhohbili3: “The trick is to use chicken with bones or skin.”
+    botton:
+      how-to-make: Here's how to make it
+      diagnosis-again: diagnosis again
+      registration: User registration
+      result: see the result of diagnosis
+  posts:
+    new:
+      TITLE: Give a rating to a dish
+    show:
+      title: Details of the rating and people's reactions
+    index:
+      title: Everyone's review
+      no_result: No postings
+    edit:
+      title: Fix food ratings
+    favorites:
+      title: “favorite” posts
+      no_result: No “favorite” posts
+    posts:
+      title: List of posts
+      no_result: No posts
+  profiles:
+    show:
+      title: Profile settings
+    edit:
+      title: edit profile
+      to_login_page: login page
+  views:
+    pagination:
+      first: “&laquo; to first”
+      last: “&raquo; to the end”
+      previous: “&lsaquo; back to previous”
+      next: “next &rsaquo;”
+      truncate: “...”
+  terms:
+    terms:
+      title: Terms of Use
+  password_resets:
+    new:
+      title: Password reset request
+      submit: Submit
+    edit:
+      title: Password reset
+    create:
+      success: Password reset instructions sent
+    update:
+      success: password changed

--- a/config/locales/view/en.yml
+++ b/config/locales/view/en.yml
@@ -110,6 +110,8 @@ en:
     If you can confirm it: If you can confirm it.
     start_button: "Diagnosis Start"
     return_button: "Return to Top Page"
+    another_diagnosis: "Would you like another diagnosis before submitting a review?"
+    click_to_comment_or_post!: "Click to comment or post!"
     georgia:
       title: What is a Georgia?
     food:
@@ -128,8 +130,9 @@ en:
     recommended: recommended here
     New registration, login: New registration, login
     lets_post_comments_and_rate_the_dishes!: "lets_post_comments_and_rate_the_dishes!"
-    Click here to share X: Click here to share X
+    Click here to share : Click here to share X
     overview: Overview
+    review: "Word of mouth reviews"
     description:
       ojakhuri: Ojakhuri
       badrijani: Badrijani
@@ -169,10 +172,16 @@ en:
       how-to-make: Here's how to make it
       diagnosis-again: diagnosis again
       registration: User registration
-      result: see the result of diagnosis
+      result: see the result
+  users:
+    new:
+      title: User Registration
+      register: Register
+      google: Click here for Google Login
   posts:
     new:
-      TITLE: Give a rating to a dish
+      title: Evaluate the food
+      subtitle: Let's share our thoughts to help other users!
     show:
       title: Details of the rating and people's reactions
     index:

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -63,10 +63,53 @@ ja:
   alerts:
     invalid_credentials: "メールまたはパスワードが間違っています。"
   static_pages:
+    title: ジョージア料理診断アプリ
+    subtitle: ガマルジョバ
+    check here before starting diagnosis: 診断始める前に、こちらを確認
     how_to_use_this_app: このアプリの使い方
+    how_to_use1: 「ガマルジョバ」
+    how_to_use2: これはジョージア語で「こんにちは」を意味する日常会話です
+    how_to_use3: 日常会話のようにみんながジョージア料理を共有することを願って、アプリの名前にしました
+    how_to_use4: 当アプリでは、簡単な診断をYESNO形式で回答後、おすすめのジョージア料理をあなたに提案いたします
+    how_to_use5: 診断した結果に応じておすすめのジョージア料理と作り方のページに遷移できます
+    how_to_use6: また、Xでのシェア機能を用いて、多くの人に共有できます
+    how_to_use7: 診断はログインの有無関係なく可能です
+    how_to_use8: ユーザー登録しログインすると、各料理の掲示板にとびます
+    how_to_use9: Google認証によるログインも下記から可能です
+    how_to_use10: ここでは自ら作った物を各料理掲示板の中で口コミをすることができ、
+    how_to_use11: 画像アップロードして投稿することもできます
+    how_to_use12: 詳細を見るとレビュー評価も確認できます
+    how_to_use13: 参考になった口コミに関しては、いいねをすることが可能です
+    how_to_use14: いいねした投稿、ユーザー自身が投稿した口コミはヘッダー上でにアクセスできます
     What kind of country is Georgia?: ジョージアって何？
+    Georgia1: 1. 面積
+    Georgia2: 6万9,700平方キロメートル（日本の約5分の1）
+    Georgia3: 2. 人口
+    Georgia4: 370万人（2023年：国連人口基金）
+    Georgia5: 3. 首都
+    Georgia6: トビリシ
+    Georgia7: 4. 民族
+    Georgia8: ジョージア系（86.8％）、アゼルバイジャン系（6.2％）、アルメニア系（4.5％）、ロシア系（0.7％）、オセチア系（0.4％）
+    Georgia9: 5. 言語
+    Georgia10: 公用語はジョージア語（コーカサス諸語に属する）
+    Georgia11: 6. 宗教
+    Georgia12: 主としてキリスト教（ジョージア正教）
+    Georgia13: 7. その他
+    Georgia14: コーカサス山脈の南側、黒海の東岸に位置し、アジアとヨーロッパをつなぐ交通の要衝
+    Georgia15: ワインの原料となるブドウの醸造文化は8000年以上の歴史があり、世界最古ともいわれている。現在もワイン生産が盛ん
     What is a Georgian_Food?: ジョージア料理って何？
+    Georgian_Food1: ジョージアは古来から数多くの民族が行き交うアジアとヨーロッパを つなぐ交通の要衝であった
+    Georgian_Food2: 歴史上、隣接する国に支配されていたことで 料理においても、アジアの要素とヨーロッパの要素を混ぜ合わせた文化が 形成し、今に至る
+    Georgian_Food3: 主食は何？
+    Georgian_Food4: 小麦を使ったパンが主食、各エリアごと山岳に囲まれていることから
+    Georgian_Food5: パン作りの材料、製法がエリアごとで異なる
+    Georgian_Food6: 北に隣接するロシアの影響で、ライ麦もよく口にする
+    Georgian_Food7: 料理の特色は？
+    Georgian_Food8: 西アジアの影響でハーブやスパイスを多用する 歯ざわりや風味付けにクルミをよく用いる
     reference_materials: "参考資料:"
+    If you can confirm it: 確認出来たら
+    start_button: "診断スタート"
+    return_button: "トップページに戻る"
     georgia:
       title: ジョージアって何？
     food:
@@ -76,13 +119,26 @@ ja:
   diagnoses:
     new:
       title: 診断スタート
+    question: 3つの質問にYESかNOで答えてね
+    question1: Question1. お酒はよく飲む
+    question2: Question2. 時間がないので、手軽に作りたい
+    question3: Question3. がっつりしたのが食べたい
     show:
       title: あなたのおすすめは
     recommended: おすすめはこちら
     New registration, login: 新規登録、ログインして
     lets_post_comments_and_rate_the_dishes!:  料理のコメント投稿、評価をしてみよう！
+    Click here to share X: Xのシェアはこちら
     overview: 概説
     description:
+      ojakhuri: オジャフリ
+      badrijani: パドリジャーニ
+      sokos_chashushuli: ソコスチャシュシュリ
+      pkhali: プパリ
+      ostri: オーストリ
+      chikirtma: チヒルトゥマ
+      shkmeruli: シュクメルリ
+      chakhohbili: チャホフビリ
       ojakhuri1: ジョージア語で「家族の食事」と言われる代表的な肉料理
       ojakhuri2: ジャガイモと玉ねぎ、豚肉、ニンニクやパクチーなどのハーブで作られる、いわば「ジョージア風ジャーマンポテト」
       ojakhuri3: ホクホクのジャガイモと、カリカリのお肉が食欲をそそるので、ビールとの相性が抜群

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -110,6 +110,8 @@ ja:
     If you can confirm it: 確認出来たら
     start_button: "診断スタート"
     return_button: "トップページに戻る"
+    another_diagnosis: "投稿前に、もう一回診断してみる？"
+    click_to_comment_or_post!: "クリックして、コメントや投稿をしてみよう"
     georgia:
       title: ジョージアって何？
     food:
@@ -128,8 +130,9 @@ ja:
     recommended: おすすめはこちら
     New registration, login: 新規登録、ログインして
     lets_post_comments_and_rate_the_dishes!:  料理のコメント投稿、評価をしてみよう！
-    Click here to share X: Xのシェアはこちら
+    Click here to share: Xのシェアはこちら
     overview: 概説
+    review: 口コミレビュー
     description:
       ojakhuri: オジャフリ
       badrijani: パドリジャーニ
@@ -170,9 +173,15 @@ ja:
       diagnosis-again: もう一度診断
       registration: ユーザー登録
       result: 診断結果を見る
+  users:
+    new:
+      title: ユーザー登録
+      register: 登録する
+      google: Googleログインの方はこちら
   posts:
     new:
       title: 料理の評価を行う
+      subtitle: 他のユーザーの参考になるように、感想を共有してみよう
     show:
       title: 評価の詳細とみんなの反応
     index:


### PR DESCRIPTION
# i18nを使って英語/日本語切り替えに対応する

最初は試験的に試すつもりだったが、日本語読めない外国人の友達がいたので、実装した

下記の英語への切り替え機能を参考に作成
https://github.com/nao-enpg/Nishinari_Izakaya_Crawl/issues/45

## application_controller.rbに翻訳するためのメソッドとメソッドの呼び出しを追加する
before_action は、アクションが実行される前に指定されたメソッドを呼び出す
application_controller.rb に記述することで、ApplicationController クラスを継承しているすべてのコントローラでbefore_action が適用される

```ruby
  before_action :set_locale
```

set_localeは各リクエストの冒頭にロケールを設定して、リクエストが持続する間はすべての文字列が指定のロケールで翻訳されるようにする
ロケールはApplicationControllerのbefore_actionで設定できる

```ruby
def default_url_options
    { locale: I18n.locale }
end
```

上のようにすることで、url_forに依存するすべてのヘルパーメソッド (root_pathやroot_urlなどの名前付きメソッドや
books_pathやbooks_urlなどのリソースルーティングを持つヘルパー) では自動的にロケール情報がクエリ文字列に含まれるようになる 
たとえば
http://localhost:3001/?locale=ja
のような形式になる


```ruby
def set_locale
    I18n.locale = params[:locale] || I18n.default_locale
end
```
リクエスト間でロケールを管理する
I18n.localeを明示的に設定しない限り、すべての訳文でデフォルトのロケールが使われる
ローカライズされたアプリケーションは、将来複数ロケールのサポートが必要 
これを行うためには、各リクエストの冒頭にロケールを設定して、
リクエストが持続する間はすべての文字列が指定のロケールで翻訳されるようにしておくべき
ロケールはApplicationControllerのbefore_actionで設定できる

## Railsアプリケーションのデフォルトの言語設定に日本語（:ja）と英語を追加する
```Ruby
config.i18n.available_locales = [:ja, :en]
```

