### PR TITLE
GoogleAnalyticsの導入

### DIFF
--- a/app/views/layouts/_google_analytics.html.erb
+++ b/app/views/layouts/_google_analytics.html.erb
@@ -1,0 +1,9 @@
+<!-- Google tag (gtag.js) -->
+<script async src="https://www.googletagmanager.com/gtag/js?id=G-CJEYHWRJYG"></script>
+<script>
+  window.dataLayer = window.dataLayer || [];
+  function gtag(){dataLayer.push(arguments);}
+  gtag('js', new Date());
+
+  gtag('config', 'G-CJEYHWRJYG');
+</script>

--- a/app/views/layouts/_google_analytics.html.erb
+++ b/app/views/layouts/_google_analytics.html.erb
@@ -1,9 +1,0 @@
-<!-- Google tag (gtag.js) -->
-<script async src="https://www.googletagmanager.com/gtag/js?id=G-CJEYHWRJYG"></script>
-<script>
-  window.dataLayer = window.dataLayer || [];
-  function gtag(){dataLayer.push(arguments);}
-  gtag('js', new Date());
-
-  gtag('config', 'G-CJEYHWRJYG');
-</script>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,7 +4,14 @@
     <%= favicon_link_tag('logo.png') %>
     <title><%= page_title(yield(:title)) %></title>
     <% if Rails.env.production? %>
-      <%= render 'layouts/google_analytics' %>
+      <!-- Google tag (gtag.js) -->
+      <script async src="https://www.googletagmanager.com/gtag/js?id=G-CJEYHWRJYG"></script>
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-CJEYHWRJYG');
+      </script>
     <% end %>
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <%= csrf_meta_tags %>
@@ -15,16 +22,6 @@
     <%= display_meta_tags %>
     <script src="https://cdn.jsdelivr.net/npm/raty-js@4.3.0/build/raty.min.js"></script>
     <link href="https://cdn.jsdelivr.net/npm/raty-js@4.3.0/src/raty.min.css" rel="stylesheet">
-    <% if (current_user.admin == false || current_user.nil?) && Rails.env.production? %>
-        <!-- Google tag (gtag.js) -->
-      <script async src="https://www.googletagmanager.com/gtag/js?id=G-CJEYHWRJYG"></script>
-      <script>
-        window.dataLayer = window.dataLayer || [];
-        function gtag(){dataLayer.push(arguments);}
-        gtag('js', new Date());
-        gtag('config', 'G-CJEYHWRJYG');
-      </script> 
-    <% end %>
   </head>
 
   <body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -15,6 +15,16 @@
     <%= display_meta_tags %>
     <script src="https://cdn.jsdelivr.net/npm/raty-js@4.3.0/build/raty.min.js"></script>
     <link href="https://cdn.jsdelivr.net/npm/raty-js@4.3.0/src/raty.min.css" rel="stylesheet">
+    <% if (current_user.admin == false || current_user.nil?) && Rails.env.production? %>
+        <!-- Google tag (gtag.js) -->
+      <script async src="https://www.googletagmanager.com/gtag/js?id=G-CJEYHWRJYG"></script>
+      <script>
+        window.dataLayer = window.dataLayer || [];
+        function gtag(){dataLayer.push(arguments);}
+        gtag('js', new Date());
+        gtag('config', 'G-CJEYHWRJYG');
+      </script> 
+    <% end %>
   </head>
 
   <body>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -3,6 +3,9 @@
   <head>
     <%= favicon_link_tag('logo.png') %>
     <title><%= page_title(yield(:title)) %></title>
+    <% if Rails.env.production? %>
+      <%= render 'layouts/google_analytics' %>
+    <% end %>
     <meta name="viewport" content="width=device-width,initial-scale=1" />
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>


### PR DESCRIPTION
# タグをRailsアプリ内に組み込む

renderメソッドを使ってlayoutファイルへ貼り付け
「_google_analytics.html.erb」をlayouts配下へ新規作成
app/views/layouts/_google_analytics.html.erb
```html
<!-- Google tag (gtag.js) -->
<script async src="https://www.googletagmanager.com/gtag/js?id=G-CJEYHWRJYG"></script>
<script>
  window.dataLayer = window.dataLayer || [];
  function gtag(){dataLayer.push(arguments);}
  gtag('js', new Date());

  gtag('config', 'G-CJEYHWRJYG');
</script>
```
app/views/layouts/application.html.erb
```html
<head>
    <--省略-->
    <% if Rails.env.production? %>
      <%= render 'layouts/google_analytics' %>
    <% end %>
    <--省略-->
</head>
```