### PR TITLE
独自ドメインの実装に伴うGoogle認証のリダイレクトURI変更

### DIFF
--- a/config/settings/production.yml
+++ b/config/settings/production.yml
@@ -1,2 +1,2 @@
 sorcery:
-  GOOGLE_CALLBACK_URL: 'https://gamarjoba.fly.dev/oauth/callback?provider=google'
+  GOOGLE_CALLBACK_URL: 'https://gamarjoba.jp/oauth/callback?provider=google'


### PR DESCRIPTION
# 1: Google Cloud側の設定
Google Cloud プロジェクトの作成
[Google Cloud Console](https://console.cloud.google.com/cloud-resource-manager)にアクセスし、既存プロジェクトを確認する

ドロップダウン「三」から、有効なAPIとサービス→認証情報、
[![Image from Gyazo](https://i.gyazo.com/9c20286f59f11984bedc33e8bef18376.png)](https://gyazo.com/9c20286f59f11984bedc33e8bef18376)

対象のクライアントを押下し、承認済みのリダイレクト URIを独自ドメインに修正する

[![Image from Gyazo](https://i.gyazo.com/62f61d5bd4c899643cde883318c82a88.png)](https://gyazo.com/62f61d5bd4c899643cde883318c82a88)

# 2: config/settings.ymlファイルの本番環境側のURLに修正変更する
config/settings/production.yml(本番環境側)のGOOGLE_CALLBACK_URLを独自ドメインに修正する

# 3: Google APIの設定と環境変数の登録
環境変数（GOOGLE_CALLBACK_URL）を fly secrets を使ってFly.ioに登録
環境変数（GOOGLE_CLIENT_ID, GOOGLE_CLIENT_SECRET)は登録済みなので、そのままにしておく
```
fly secrets set GOOGLE_CALLBACK_URL=ZZZZZZZZZZZZZZZZZZZZZZZZZZZ
```
# 4: デプロイ再実行
fly.ioの環境で再度デプロイしなおす
```
fly deploy
```
Googleアカウントで独自ドメインの状態でログインできているのを確認する

[![Image from Gyazo](https://i.gyazo.com/8521c37a9f8088975478c8af9a3bb49f.png)](https://gyazo.com/8521c37a9f8088975478c8af9a3bb49f)

[![Image from Gyazo](https://i.gyazo.com/a01103dc623613660d2ead375f96dfa1.png)](https://gyazo.com/a01103dc623613660d2ead375f96dfa1)