### PR TITLE
スリープ対策

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -12,7 +12,7 @@ primary_region = 'nrt'
 [http_service]
   internal_port = 3000
   force_https = true
-  auto_stop_machines = 'stop'
+  auto_stop_machines = false
   auto_start_machines = true
   min_machines_running = 0
   processes = ['app']


### PR DESCRIPTION
# スリープ対策
下記の記事を参考にauto_stop_machinesの値をfalseに設定変更
https://community.fly.io/t/how-to-increase-app-sleep-threshold/17783/2