### PR TITLE
Admin preparation

### DIFF
--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -28,6 +28,10 @@ class User < ApplicationRecord
   # 今回の場合では、掲示板が削除されたときに、そのユーザーに関連するCommentsレコードも一緒に削除される
   validates :reset_password_token, presence: true, uniqueness: true, allow_nil: true
 
+  enum role: { general: 0, admin: 1 }
+  # 上記の記述で role カラム(integer)の値に応じて、そのユーザーが general（一般）か admin（管理者）が判別できるようになる
+  # 先程のマイグレーションファイルの default: 0 によって role カラムが 0 のユーザーは general となる
+  
   def own?(object)
     # own? メソッドについて
     # own? メソッド

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -31,7 +31,7 @@ class User < ApplicationRecord
   enum role: { general: 0, admin: 1 }
   # 上記の記述で role カラム(integer)の値に応じて、そのユーザーが general（一般）か admin（管理者）が判別できるようになる
   # 先程のマイグレーションファイルの default: 0 によって role カラムが 0 のユーザーは general となる
-  
+
   def own?(object)
     # own? メソッドについて
     # own? メソッド

--- a/db/migrate/20250121001554_add_role_to_users.rb
+++ b/db/migrate/20250121001554_add_role_to_users.rb
@@ -1,0 +1,5 @@
+class AddRoleToUsers < ActiveRecord::Migration[7.2]
+  def change
+    add_column :users, :role, :integer, null: false, default: 0
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.2].define(version: 2024_12_19_002158) do
+ActiveRecord::Schema[7.2].define(version: 2025_01_21_001554) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -73,6 +73,7 @@ ActiveRecord::Schema[7.2].define(version: 2024_12_19_002158) do
     t.datetime "reset_password_token_expires_at"
     t.datetime "reset_password_email_sent_at"
     t.integer "access_count_to_reset_password_page", default: 0
+    t.integer "role", default: 0, null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token"
   end


### PR DESCRIPTION
# Users テーブルに role カラムを追加
Users テーブルに role カラムを追加するマイグレーションファイルを作成するためにターミナルにて Users テーブルに role カラムを追加するマイグレーションファイルを生成するコマンドを実行する
````Shell
rails generate migration AddRoleToUsers role:integer
````
生成されたマイグレーションファイルは以下のように編集
````Ruby
class AddRoleToUsers < ActiveRecord::Migration[7.2]
  def change
    add_column :users, :role, :integer, null: false, default: 0
  end
end
````
上記が反映されることで Users テーブルに role カラムが追加されることに加えて、 role カラムにはデフォルトで 0 が登録される
# User モデルに enum を定義
app/models/user.rb を以下のように編集
````Ruby
class User < ApplicationRecord
# 省略
  has_many 
# 省略
  enum role: { general: 0, admin: 1 }
# 省略
end
````
上記の記述で role カラム(integer)の値に応じて、そのユーザーが general（一般）か admin（管理者）が判別できるようになる 
先程のマイグレーションファイルの default: 0 によって role カラムが 0 のユーザーは general となる

# role を admin に変更する
以下のコマンドをターミナルにて実行して、Rails コンソールを立ち上げ、現在ログインしているユーザーの role を admin に変更する
````
# docker compose upが実行されているターミナルとは別のターミナルを用意して以下を実行する

$ docker compose exec web rails c

- user = User.find_by(email: 'xxxxx')   # xxxxxには、現在ログインしているユーザーのメールアドレスを記入
- user.role   # 現在ログインしているユーザーの role を確認
- user.admin!   # 現在ログインしているユーザーの role を admin に変更

# 上記操作で現在ログインしているユーザーの role が admin になっているかを確認
- user = User.find_by(email: 'xxxxx')
- user.role
````
