### PR TITLE
fly.tomlでスペックを下げ、再デプロイ

### DIFF
--- a/fly.toml
+++ b/fly.toml
@@ -18,6 +18,6 @@ primary_region = 'nrt'
   processes = ['app']
 
 [[vm]]
-  memory = '1gb'
   cpu_kind = 'shared'
   cpus = 1
+  memory_mb = 256


### PR DESCRIPTION
# 理由
 fly.ioには無料枠が3VM分あるが、普通にデプロイしたら課金(11ドル近く)されたから
デフォルトでは無料枠のスペックをオーバーするのが原因なので、そこを修正する必要がある

# 方法
下記技術記事、公式記事を参考に実装
fly.tomlのvmを確認し、memory_mb = 256に変更する
memory = '1gb'はFly.io の デフォルト値（1GB RAM） が優先される可能性があり、無料枠を超えてしまうので、削除する
fly.toml
``````fly.toml
[[vm]]
# memory = '1gb'を削除
  cpu_kind = 'shared'
  cpus = 1
  memory_mb = 256 # 下記を追加
``````

修正後に再デプロイする
``````bash
fly deploy
``````
下記のコマンドにて現在のVMのスペックを確認し、デプロイしたアプリ「gamarjoba」は2つのマシンが正常に立ち上がっている且つ「started」状態になっていて、サイズも「shared-cpu-1x:256MB」となっているか確認する
``````bash
fly machines list
``````
``````bash
itok1000@ItoKen:~/graduation$ fly machines list
2 machines have been retrieved from app gamarjoba.
View them in the UI here

gamarjoba
ID              NAME            STATE   CHECKS  REGION  ROLE    IMAGE                                           IP ADDRESS                      VOLUME  CREATED                    LAST UPDATED            PROCESS GROUP   SIZE                
7811616a963668  wild-leaf-839   started         nrt             gamarjoba:deployment-XXXXXXXXXXXXXXX
XXXXXXXXXXXXXXX         2024-11-14T00:56:57Z       2025-01-30T05:07:26Z    app             shared-cpu-1x:256MB
784e667b47e238  winter-sun-8991 started         nrt             gamarjoba:deployment-XXXXXXXXXXXXXXX
XXXXXXXXXXXXXXX         2024-11-14T00:57:36Z       2025-01-30T05:06:50Z    app             shared-cpu-1x:256MB
``````
# 参考
https://zenn.dev/rrraaa/articles/1c7c79d51786c7

https://fly.io/docs/about/pricing/

https://fly.io/docs/reference/configuration/