### PR TITLE
Auto complete

### DIFF
--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,6 +1,7 @@
 import { Application } from "@hotwired/stimulus"
-
+import { Autocomplete } from 'stimulus-autocomplete'   //コンポーネントを読み込むための記述
 const application = Application.start()
+application.register('autocomplete', Autocomplete)  //コンポーネントにあるAutocompleteコントローラを使えるようにするための記述
 
 // Configure Stimulus development experience
 application.debug = false

--- a/app/javascript/controllers/autocomplete_controller.js
+++ b/app/javascript/controllers/autocomplete_controller.js
@@ -1,0 +1,6 @@
+import { Controller } from "@hotwired/stimulus";
+import { Autocomplete } from "stimulus-autocomplete";
+
+export default class extends Autocomplete {
+  // オートコンプリートのカスタムロジックが必要な場合はここに追加できます
+}

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "nodemon": "^3.1.4",
     "postcss": "^8.4.45",
     "postcss-cli": "^11.0.0",
-    "sass": "^1.78.0"
+    "sass": "^1.78.0",
+    "stimulus-autocomplete": "^3.1.0"
   },
   "browserslist": [
     "defaults"

--- a/yarn.lock
+++ b/yarn.lock
@@ -708,6 +708,11 @@ slash@^5.0.0, slash@^5.1.0:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.0.tgz#16b809c162517b5b8c3e7dcd315a2a5c2612b2af"
   integrity sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==
 
+stimulus-autocomplete@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/stimulus-autocomplete/-/stimulus-autocomplete-3.1.0.tgz#7c9292706556ed0a87abf60ea2688bf0ea1176a8"
+  integrity sha512-SmVViCdA8yCl99oV2kzllNOqYjx7wruY+1OjAVsDTkZMNFZG5j+SqDKHMYbu+dRFy/SWq/PParzwZHvLAgH+YA==
+
 string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"


### PR DESCRIPTION
# 概要
オートコンプリート検索の実装を行う

# 方法
下記の公式記事と技術記事を参考に作成を進める
https://github.com/afcapel/stimulus-autocomplete?tab=readme-ov-file
https://qiita.com/Yamamoto-Masaya1122/items/879d6eb540ce4e05cfe5

 ## 1. stimulus-autocompleteをインストール
Esbuild方式を採用しているので、npm からパッケージをインストールする
```bash
yarn add stimulus-autocomplete 
```
app/javascript/controllers/application.jsにstimulus-autocompleteの設定を追加する
```js
import { Application } from "@hotwired/stimulus"
import { Autocomplete } from 'stimulus-autocomplete'   //コンポーネントを読み込むための記述
const application = Application.start()
application.register('autocomplete', Autocomplete)  //コンポーネントにあるAutocompleteコントローラを使えるようにするための記述

// Configure Stimulus development experience
application.debug = false
window.Stimulus   = application

export { application }
```
application.register('autocomplete', Autocomplete)の記述により、HTML内でdata-controller="autocomplete"の属性をもつ要素に対して、[Autocompleteコントローラ](https://github.com/afcapel/stimulus-autocomplete/blob/main/src/autocomplete.js)の機能が適用される

 ## 2. stimulus-autocompleteのコントローラを作成
app/javascript/controllers/autocomplete_controller.js を作成し、以下のように編集する
```js
import { Controller } from "@hotwired/stimulus";
import { Autocomplete } from "stimulus-autocomplete";

export default class extends Autocomplete {
  // オートコンプリートのカスタムロジックが必要な場合はここに追加
}
```