### PR TITLE
gem 'enum_help'を導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -21,85 +21,30 @@ gem "cssbundling-rails"
 gem "jbuilder"
 # Use Redis adapter to run Action Cable in production
 # gem "redis", ">= 4.0.1"
-# gem 'rails-i18n'を導入
 gem "rails-i18n", "~> 7.0.0"
 
 gem "meta-tags"
-#### ** 画像を合成する役割のために使用 ** ####
-# アップロードされた画像が強制的にそのサイズに引き伸ばされてしまうのを防ぐ
-# OGPを使ったXのシェア機能においても万能
+
 gem "mini_magick"
 # Use Kredis to get higher-level data types in Redis [https://github.com/rails/kredis]
 # gem "kredis"
 
-#### ** デバック時に必要 ** ####
-# pry-byebugの主な機能は以下のとおり
-# - ステップ実行：
-# -コードを1行ずつ実行し、プログラムの流れを詳細に追跡できる
-# - これにより、エラーの原因を特定しやすくなる
-
-# - ブレークポイント：
-# -特定の行でプログラムの実行を停止し、その時点の変数の状態やプログラムの状況を確認できる
-
-# - インタラクティブシェル：
-# - その場でコードを試したり、メソッドの定義場所を確認したりすることができる
 gem "pry-byebug"
-# プログラムのエラーやバグを見つけて修正する時、デバックが必要だが、
-# 　そのときに使用されるGemが"pry-byebug"になる
 
-# コードを読み返す、ログを確認する、デバッグツールを使用するなどがある
-# デバッグツールを使うと、プログラムの実行を途中で止めて変数の値を確認したり、ステップごとに実行を追跡することができる
-# これにより、エラーの原因を効率的に見つけ出すことができる
-
-#### ** ユーザー登録機能時に必要 ** ####
-#### **Gemfileに gem 'sorcery', '0.16.3' を記述する**
-# Railsプロジェクトで使用するgem（ライブラリ）を管理するファイル
-# このファイルにはプロジェクトに必要なすべてのgemが記述される
-# bundle install コマンドを実行すると、Gemfileに記載されたgemがインストールされる
-# 開発者はプロジェクトの依存関係を一元的に管理し、他の開発者と環境を一致させることができる
-# Gemfileでは、gemの名前と必要に応じたバージョン指定を行うことにより、プロジェクトが必要とする正確なgemが提供され、バージョンの衝突や不整合が防げる
 gem "sorcery"
 # Use Active Model has_secure_password [https://guides.rubyonrails.org/active_model_basics.html#securepassword]
 # gem "bcrypt", "~> 3.1.7"
 
-
-#### ** 画像アップロード機能時に必要 ** ####
-# ファイルアップロードを簡単に行うためのRubyライブラリ
-# 画像やビデオなどのファイルをWebアプリケーションにアップロードし、管理する機能を提供する
-# これにより、複雑なアップロード処理を簡素化することができる
-# ファイルのリサイズやフォーマット変換、バリデーションなどの機能も提供しており、
-# ユーザーがアップロードしたファイルの安全性と品質を確保するのに役立つ
-gem "carrierwave", "~> 3.0"
-
-# 開発環境やテスト環境で環境変数を管理するためのライブラリ
-# これを使うことで、環境ごとに異なる設定を簡単に管理できる
 gem "dotenv", groups: [ :development, :test ]
-# CarrierWaveと連携してAmazon S3に画像やファイルをアップロードするために必要なライブラリ
-# このライブラリを使用することで、CarrierWaveはAmazon S3と連携し、クラウドストレージにファイルを保存することができる
+
 gem "fog-aws"
-# RubyでAWS S3を使うためには、aws-sdk-s3というgemをインストールする必要がある
+
 gem "aws-sdk-s3"
 
-### ** ページネーションの実装に必要 ** ####
-# Ruby on Rails アプリケーションでページネーション機能を簡単に実装するためのライブラリ
-# この gem を使うと、大量のデータを効率的に分割し、ユーザーにページングされたビューを提供することができる
-# カスタマイズ性が高く、デフォルトの設定を簡単に変更できるほか、Bootstrap などの CSS フレームワークと統合してスタイリングを行うことも可能
 gem "kaminari", "1.2.2"
-#### ** ユーザーに表示するデータを整形・加工する時に必要 ** ####
-# # **Draper（ドレッパー）**
-# Draperとは、Ruby on Railsで使うgemの一つ
-# Draperをインストールすると、デコレーターを作成できるようになり、ユーザーに表示するデータを整形・加工するための処理（ビューに関するロジック）をモデルから分離し、コードの保守性と読みやすさを向上させることができる
+
 gem "draper", "4.0.2"
 
-#### ** 高度な検索機能を作る時に必要 ** ####
-# # **ransack**
-# Ruby on Rails アプリケーションに高度な検索機能を簡単に追加するための gemの一つ
-# ransackは、検索フォームの作成から検索クエリの生成、検索結果の表示までを包括的にサポートする
-# ransackの主な機能は次のとおり
-# 検索フォームの生成 ： ransackは、簡単に検索フォームを生成するためのヘルパーメソッドを提供する
-# 柔軟な検索条件 ： 部分一致検索、完全一致検索、範囲検索など、さまざまな検索条件をサポートする
-# ソート機能 ： 検索結果を特定のカラムでソートする機能も提供する
-# シンプルな構文 ： ransackはシンプルなRuby構文を使用しているため、既存のコードに容易に統合できる
 gem "ransack", ">= 3.2.1"
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem "tzinfo-data", platforms: %i[ windows jruby ]
@@ -120,13 +65,7 @@ group :development, :test do
 
   # Omakase Ruby styling [https://github.com/rails/rubocop-rails-omakase/]
   gem "rubocop-rails-omakase", require: false
-  # RSpec
-  # Rubyプログラミング言語用のテストフレームワーク
-  # Railsと組み合わせて使用することが多く、Railsアプリケーションの自動テストを作成するために便利
-  # プログラミング初学者にも利用しやすい
-  # 自然言語に近い構文を使用するため、テストコードの読み書きがしやすくなっている
-  # 豊富な機能を活用することで、初学者でも効果的なテストコードを作成することができる
-  # 初めてのテストコード作成においても、RSpecを利用することで品質の高いコードを開発する手助けになる
+
   gem "rspec-rails"
   gem "factory_bot_rails"
 end
@@ -143,19 +82,13 @@ group :test do
   gem "webdrivers"
 end
 
-# gem 'letter_opener_web'は、Railsアプリケーションの開発環境において、送信されるメールをブラウザで確認できるgem
-# メールの送信処理が実行されると、メールの内容がブラウザ上で表示され、実際にメールが送信されることなく内容を確認することができる
-# これにより、メールの内容やフォーマットを簡単に確認・修正することが可能となる
 group :development do
   gem "letter_opener"
   gem "letter_opener_web", "~> 2.0"
 end
 
-# Railsアプリケーションで設定管理を簡単に行うためのgem
-# 環境ごとに異なる設定を一元管理することができ、開発環境、テスト環境、本番環境で異なる設定値を使いたい場合に非常に便利
-# config/settings.ymlファイル に共通の設定を書き、config/settings/development.yml、config/settings/production.yml、
-# config/settings/test.yml に環境ごとの設定を書き分ける
 gem "config"
 
-# Ruby用のコードカバレッジ解析ツール
 gem "simplecov", require: false, group: :test
+
+gem "enum_help"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -113,13 +113,6 @@ GEM
       rack-test (>= 0.6.3)
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
-    carrierwave (3.0.7)
-      activemodel (>= 6.0.0)
-      activesupport (>= 6.0.0)
-      addressable (~> 2.6)
-      image_processing (~> 1.1)
-      marcel (~> 1.0.0)
-      ssrf_filter (~> 1.0)
     coderay (1.1.3)
     concurrent-ruby (1.3.4)
     config (5.5.2)
@@ -145,6 +138,8 @@ GEM
       request_store (>= 1.0)
       ruby2_keywords
     drb (2.2.1)
+    enum_help (0.0.19)
+      activesupport (>= 3.0.0)
     erubi (1.13.0)
     excon (1.2.1)
     factory_bot (6.5.0)
@@ -158,12 +153,6 @@ GEM
       logger
     faraday-net_http (3.4.0)
       net-http (>= 0.5.0)
-    ffi (1.17.0-aarch64-linux-gnu)
-    ffi (1.17.0-arm-linux-gnu)
-    ffi (1.17.0-arm64-darwin)
-    ffi (1.17.0-x86-linux-gnu)
-    ffi (1.17.0-x86_64-darwin)
-    ffi (1.17.0-x86_64-linux-gnu)
     fog-aws (3.29.0)
       base64 (~> 0.2.0)
       fog-core (~> 2.6)
@@ -186,9 +175,6 @@ GEM
     hashie (5.0.0)
     i18n (1.14.6)
       concurrent-ruby (~> 1.0)
-    image_processing (1.13.0)
-      mini_magick (>= 4.9.5, < 5)
-      ruby-vips (>= 2.0.17, < 3)
     io-console (0.7.2)
     irb (1.14.0)
       rdoc (>= 4.0.0)
@@ -404,9 +390,6 @@ GEM
       rubocop-performance
       rubocop-rails
     ruby-progressbar (1.13.0)
-    ruby-vips (2.2.2)
-      ffi (~> 1.12)
-      logger
     ruby2_keywords (0.0.5)
     rubyzip (2.3.2)
     securerandom (0.3.1)
@@ -436,7 +419,6 @@ GEM
       actionpack (>= 6.1)
       activesupport (>= 6.1)
       sprockets (>= 3.0.0)
-    ssrf_filter (1.2.0)
     stimulus-rails (1.3.4)
       railties (>= 6.0.0)
     stringio (3.1.1)
@@ -483,12 +465,12 @@ DEPENDENCIES
   bootsnap
   brakeman
   capybara
-  carrierwave (~> 3.0)
   config
   cssbundling-rails
   debug
   dotenv
   draper (= 4.0.2)
+  enum_help
   factory_bot_rails
   fog-aws
   jbuilder


### PR DESCRIPTION
# 目的
掲示板/ユーザのCRUD機能の作成する

# 方法
## gem 'enum_help', '0.0.19'を導入
Gemfileにgem 'enum_help', '0.0.19'を追記して、bundle install（Dockerを使用）を行い、各サーバーを立ち上げ直す
````ruby
gem 'enum_help'
````

### gem 'enum_help'
enumで定義した値を簡単にi18n化するためのgem
enumに対して人間が読みやすいラベルを簡単に付けることができ、ビューやフォームでの表示がわかりやすくなる
