### PR TITLE
管理画面上でユーザーのCRUD機能(ルート側とコントローラー側)

### DIFF
--- a/app/controllers/admin/users_controller.rb
+++ b/app/controllers/admin/users_controller.rb
@@ -1,0 +1,36 @@
+class Admin::UsersController < Admin::BaseController
+    before_action :set_user, only: %i[show edit update destroy]
+
+    def index
+      @q = User.ransack(params[:q])
+      @users = @q.result(distinct: true).order(created_at: :desc).page(params[:page]).per(10)
+    end
+
+    def show; end
+
+    def edit; end
+
+    def update
+      if @user.update(user_params)
+        redirect_to admin_user_path(@user), success: t("defaults.flash_message.updated", item: User.model_name.human)
+      else
+        flash.now[:danger] = t("defaults.flash_message.not_updated", item: User.model_name.human)
+        render :edit
+      end
+    end
+
+    def destroy
+      @user.destroy!
+      redirect_to admin_users_path, success: t("defaults.flash_message.deleted", item: User.model_name.human), status: :see_other
+    end
+
+    private
+
+    def set_user
+      @user = User.find(params[:id])
+    end
+
+    def user_params
+      params.require(:user).permit(:user_name, :avatar, :role)
+    end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -56,5 +56,6 @@ Rails.application.routes.draw do
     get "login" => "user_sessions#new", :as => :login
     post "login" => "user_sessions#create"
     delete "logout" => "user_sessions#destroy", :as => :logout
+    resources :users, only: %i[index show edit update destroy]
   end
 end


### PR DESCRIPTION
## 管理画面のユーザーと掲示板のCRUDのルートを設定する
config/routes.rbにて、
````ruby
resources :users, only: %i[index show edit update destroy]
 # 管理側のユーザーのリソース(一覧、詳細、編集、更新、削除)
````
上記を記載することで、管理画面のユーザー一覧とユーザーおよびユーザー詳細閲覧のルーティングが設定される
update、destroyを記載することで、
USERメソッドで/usersというURLパターンにリクエストが飛んだ際、
usersコントローラーのupdateアクション、destroyアクションが動くように定義される
また、URLパターンを生成してくれる posts_pathとusers_path（URLヘルパー）も生成される

## ユーザーのCRUD
以下のユーザー関連のビューファイルを使って、管理画面上でユーザーのCRUD機能を実装
コントローラー側
app/controllers/admin/users_controllers.rb
````ruby
class Admin::UsersController < Admin::BaseController
    before_action :set_user, only: %i[show edit update destroy]

    def index
      @q = User.ransack(params[:q])
      @users = @q.result(distinct: true).order(created_at: :desc).page(params[:page]).per(10)
    end

    def show; end

    def edit; end

    def update
      if @user.update(user_params)
        redirect_to admin_user_path(@user), success: t("defaults.flash_message.updated", item: User.model_name.human)
      else
        flash.now[:danger] = t("defaults.flash_message.not_updated", item: User.model_name.human)
        render :edit
      end
    end

    def destroy
      @user.destroy!
      redirect_to admin_users_path, success: t("defaults.flash_message.deleted", item: User.model_name.human), status: :see_other
    end

    private

    def set_user
      @user = User.find(params[:id])
    end

    def user_params
      params.require(:user).permit(:user_name, :avatar, :role)
    end
end
````