### PR TITLE
管理画面上で口コミのCRUD機能(ルート側とコントローラー側)

### DIFF
--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -1,35 +1,35 @@
 class Admin::PostsController < Admin::BaseController
     before_action :set_post, only: %i[show edit update destroy]
-  
+
     def index
       @q = Post.ransack(params[:q])
       @posts = @q.result(distinct: true).page(params[:page]).per(10)
     end
-  
+
     def show; end
-  
+
     def edit; end
-  
+
     def update
       @q = Post.ransack(params[:q])
       if @post.update(post_params)
-        redirect_to admin_post_path(@post), success: t('defaults.flash_message.updated', item: Post.model_name.human), status: :see_other
+        redirect_to admin_post_path(@post), success: t("defaults.flash_message.updated", item: Post.model_name.human), status: :see_other
       else
-        flash.now[:danger] = t('defaults.flash_message.not_updated', item: Post.model_name.human)
+        flash.now[:danger] = t("defaults.flash_message.not_updated", item: Post.model_name.human)
       end
     end
-  
+
     def destroy
       @post.destroy!
-      redirect_to admin_posts_path, success: t('defaults.flash_message.deleted', item: Post.model_name.human), status: :see_other
+      redirect_to admin_posts_path, success: t("defaults.flash_message.deleted", item: Post.model_name.human), status: :see_other
     end
-  
+
     private
-  
+
     def set_post
       @post = Post.find(params[:id])
     end
-  
+
     def post_params
       params.require(:post).permit(:title, :body, :post_image, :post_image_cache)
     end

--- a/app/controllers/admin/posts_controller.rb
+++ b/app/controllers/admin/posts_controller.rb
@@ -1,0 +1,36 @@
+class Admin::PostsController < Admin::BaseController
+    before_action :set_post, only: %i[show edit update destroy]
+  
+    def index
+      @q = Post.ransack(params[:q])
+      @posts = @q.result(distinct: true).page(params[:page]).per(10)
+    end
+  
+    def show; end
+  
+    def edit; end
+  
+    def update
+      @q = Post.ransack(params[:q])
+      if @post.update(post_params)
+        redirect_to admin_post_path(@post), success: t('defaults.flash_message.updated', item: Post.model_name.human), status: :see_other
+      else
+        flash.now[:danger] = t('defaults.flash_message.not_updated', item: Post.model_name.human)
+      end
+    end
+  
+    def destroy
+      @post.destroy!
+      redirect_to admin_posts_path, success: t('defaults.flash_message.deleted', item: Post.model_name.human), status: :see_other
+    end
+  
+    private
+  
+    def set_post
+      @post = Post.find(params[:id])
+    end
+  
+    def post_params
+      params.require(:post).permit(:title, :body, :post_image, :post_image_cache)
+    end
+end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -57,5 +57,6 @@ Rails.application.routes.draw do
     post "login" => "user_sessions#create"
     delete "logout" => "user_sessions#destroy", :as => :logout
     resources :users, only: %i[index show edit update destroy]
+    resources :posts, only: %i[index show edit update destroy]
   end
 end


### PR DESCRIPTION
## 管理画面のユーザーと掲示板のCRUDのルートを設定する
config/routes.rbにて、
````ruby
resources :posts, only: %i[index show edit update destroy]
 # 管理側の口コミのリソース(一覧、詳細、編集、更新、削除)
````
上記を記載することで、管理画面の口コミ一覧と口コミ詳細閲覧のルーティングが設定される
update、destroyを記載することで、
POSTメソッドで/usersというURLパターンにリクエストが飛んだ際、
postsコントローラーのupdateアクション、destroyアクションが動くように定義される
また、URLパターンを生成してくれる posts_path（URLヘルパー）も生成される

## 口コミのCRUD
以下のユーザー関連のビューファイルを使って、管理画面上で口コミのCRUD機能を実装
コントローラー側
app/controllers/admin/posts_controllers.rb
````ruby
class Admin::PostsController < Admin::BaseController
    before_action :set_post, only: %i[show edit update destroy]
  
    def index
      @q = Post.ransack(params[:q])
      @posts = @q.result(distinct: true).page(params[:page]).per(10)
    end
  
    def show; end
  
    def edit; end
  
    def update
      @q = Post.ransack(params[:q])
      if @post.update(post_params)
        redirect_to admin_post_path(@post), success: t('defaults.flash_message.updated', item: Post.model_name.human), status: :see_other
      else
        flash.now[:danger] = t('defaults.flash_message.not_updated', item: Post.model_name.human)
      end
    end
  
    def destroy
      @post.destroy!
      redirect_to admin_posts_path, success: t('defaults.flash_message.deleted', item: Post.model_name.human), status: :see_other
    end
  
    private
  
    def set_post
      @post = Post.find(params[:id])
    end
  
    def post_params
      params.require(:post).permit(:title, :body, :post_image, :post_image_cache)
    end
end
````