### PR TITLE
フッターの修正(instagramのアイコンリンクを追加)

### DIFF
--- a/app/views/shared/_footer.html.erb
+++ b/app/views/shared/_footer.html.erb
@@ -5,20 +5,21 @@
           <%= link_to t('footer.privacy_policy'), 'https://www.kiyac.app/privacypolicy/FjpZb0f14mVOOlbu7Bdk', class: "nav-link" %>
           <%= link_to t('footer.terms_of_Use'), terms_path ,class: 'nav-link' %>
           <%= link_to  t('footer.contact_us'),"https://docs.google.com/forms/d/e/1FAIpQLSfGv6xKuATPkIRM57hOeL6fAwSo-hnu4CyrhzpKDKQ386I9cg/viewform?embedded=true", class: 'nav-link' %>
-          </ul>
+         </ul>
       </div>
-      <ul class='navbar-nav ms-auto main-nav align-items-center'>
-       © 2024. Itok1000
-       <div class="d-flex justify-content-end align-items-center">
-       <!-- GitHubリンク -->
-       <%= link_to "https://github.com/Itok1000/master", class: "mx-2", target: "_blank" do %>
-        <img width="30" height="30" src="https://img.icons8.com/ios-glyphs/30/github.png" alt="github"/>
-       <% end %>
-      <!-- Xリンク -->
-      <%= link_to "https://x.com/Itoken1000", class: "mx-2", target: "_blank" do %>
-        <img width="30" height="30" src="https://img.icons8.com/ios-filled/50/twitterx--v1.png" alt="twitterx--v1"/> <!-- ロゴファイルのパスを指定 -->
-      <% end %>
-      </ul>
-    </div>
+       <ul class='navbar-nav ms-auto main-nav align-items-center'>
+        <div class= "nav-link" >© 2024. Itok1000</div>
+        <div class="d-flex justify-content-end align-items-center">
+         <%= link_to "https://github.com/Itok1000/master", class: "mx-2", target: "_blank" do %>
+          <i class="bi bi-github" style="color: #ffffff;"></i>
+         <% end %>
+         <%= link_to "https://x.com/Itoken1000", class: "mx-2", target: "_blank" do %>
+          <i class="bi bi-twitter-x" style="color: #ffffff;"></i>
+         <% end %>
+         <%= link_to "https://www.instagram.com/uotiatnek2525/?igsh=OGQ5ZDc2ODk2ZA%3D%3D&utm_source=qr", class: "mx-2", target: "_blank" do %>
+          <i class="bi bi-instagram" style="color: #ffffff;"></i>
+         <% end %>
+        </div>
+       </ul>
   </nav>
 </footer>


### PR DESCRIPTION
# 目的
フッターのアイコンリンクにinstagramのアイコンを追加し、個人的には自身のフォロワーを増やすのとBeOpenの意識を持つため

# 対応
下記の資料を参考に追加
また、コメントアウトが残っていたので、削除
https://icons.getbootstrap.jp/?q=face