### PR TITLE
フォーム入力時のエラー情報を修正

### DIFF
--- a/app/views/shared/_error_messages.html.erb
+++ b/app/views/shared/_error_messages.html.erb
@@ -1,6 +1,7 @@
 <% if object.errors.any? %>
   <div id="error_explanation" class="alert alert-danger">
     <ul class="mb-0">
+      <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button>
       <% object.errors.each do |error| %>
         <li><%= error.full_message %></li>
       <% end %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -5,7 +5,6 @@
     <div class="col-md-10 col-lg-8 mx-auto">
       <h1><%= t('users.new.title') %></h1>
       <%= form_with model: @user do |f| %>
-        <!-- エラーメッセージの表示 -->
         <%= render 'shared/error_messages', object: @user %>
         <div class="mb-3">
           <%= f.label :user_name, class: "form-label" %>


### PR DESCRIPTION
 # 修正箇所
フォーム入力時のエラー情報に閉じるボタンを追加
Before 
[![Image from Gyazo](https://i.gyazo.com/69c61aaa9ce3b011da8ad95125fa88ff.png)](https://gyazo.com/69c61aaa9ce3b011da8ad95125fa88ff)
After
[![Image from Gyazo](https://i.gyazo.com/f87e74fb7584e2bb822d2c8cbfa06da0.png)](https://gyazo.com/f87e74fb7584e2bb822d2c8cbfa06da0)