### PR TITLE
Bulletの導入

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -71,6 +71,7 @@ group :development, :test do
 
   gem "rspec-rails"
   gem "factory_bot_rails"
+  gem "bullet"
 end
 
 group :development do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -103,6 +103,9 @@ GEM
     brakeman (7.0.0)
       racc
     builder (3.3.0)
+    bullet (8.0.1)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     byebug (11.1.3)
     capybara (3.40.0)
       addressable
@@ -449,6 +452,7 @@ GEM
     tzinfo (2.0.6)
       concurrent-ruby (~> 1.0)
     unicode-display_width (2.5.0)
+    uniform_notifier (1.16.0)
     uri (1.0.2)
     useragent (0.16.10)
     version_gem (1.1.4)
@@ -482,6 +486,7 @@ DEPENDENCIES
   aws-sdk-s3
   bootsnap
   brakeman
+  bullet
   capybara
   carrierwave (~> 3.0)
   config

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -1,6 +1,15 @@
 require "active_support/core_ext/integer/time"
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.alert         = true
+    Bullet.bullet_logger = true
+    Bullet.console       = true
+    Bullet.rails_logger  = true
+    Bullet.add_footer    = true
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
   config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.perform_deliveries = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -6,6 +6,12 @@ require "active_support/core_ext/integer/time"
 # and recreated between test runs. Don't rely on the data there!
 
 Rails.application.configure do
+  config.after_initialize do
+    Bullet.enable        = true
+    Bullet.bullet_logger = true
+    Bullet.raise         = true # raise an error if n+1 query occurs
+  end
+
   # Settings specified here will take precedence over those in config/application.rb.
   config.action_mailer.delivery_method = :test
   config.action_mailer.perform_deliveries = false


### PR DESCRIPTION
# 目的
ゆるふわLT会で一部の人から話題になってた「Bullet」を導入することにしてみた
https://zenn.dev/mochiblock/articles/89f8bf248b1bd8

# Bulletとは
N+1問題を検知してくれるgemfile
公式のGitHubによると
https://github.com/flyerhzm/bullet

クエリの回数を減らすことでアプリケーションのRailsのパフォーマンスを向上させるように設計されているのが目的

アプリケーションの開発中にクエリを監視し、いつeager loading（N+1クエリ）を追加すべきか、いつ不要なeager loadingを使用しているか、いつカウンターキャッシュを使用すべきかを通知してくれる

# N+1問題
SQLが必要以上に実行されてしまいパフォーマンスが落ちる問題
indexアクションにて.all などで取得した場合で起きる
データ量が増えてくると、処理が完了するまでにかかる時間も次第に長くなり、アプリケーションのパフォーマンスに悪影響を及ぼす
N+1問題を防ぐには、includesメソッドを用いて関連付けを予め指定し、クエリの読み込み回数を最小限にする

# 対応方法
Gemfileにbulletを記述し、インストールする
````Ruby
gem "bullet"
````
````bash
docker compose run web bundle install
````
generateコマンドでBullet gemを有効にする
````bash
docker compose run web bundle exec rails g bullet:install
 ✔ Container graduation-db-1  Running                                                                                                              0.0s 
Enabled bullet in config/environments/development.rb
Would you like to enable bullet in test environment? (y/n) y
Enabled bullet in config/environments/test.rb
````
generateコマンドはデフォルトの設定を下記のようにconfig/environments/development.rbとconfig/environments/test.rbに自動生成される
config/environments/development.rb
````Ruby
config.after_initialize do
    Bullet.enable        = true
    Bullet.alert         = true
    Bullet.bullet_logger = true
    Bullet.console       = true
    Bullet.rails_logger  = true
    Bullet.add_footer    = true
 end
````
config/environments/test.rb
````Ruby
config.after_initialize do
    Bullet.enable        = true
    Bullet.bullet_logger = true
    Bullet.raise         = true # raise an error if n+1 query occurs
 end
````
設定の主な内容
Bullet.enable: Bullet gemを有効にする
Bullet.alert: ブラウザにJavaScriptアラートを表示する
Bullet.bullet_logger: Bullet ログファイル (Rails.root/log/bullet.log) にログを記録する
Bullet.console: ブラウザの console.log に警告を記録する
Bullet.rails_logger: Railsログに直接警告を追加する
Bullet.add_footer: ページの左下隅に詳細を追加する
Bullet.raise: エラーを発生させる