### PR TITLE
better_errorsのインストール

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -77,6 +77,8 @@ end
 group :development do
   # Use console on exceptions pages [https://github.com/rails/web-console]
   gem "web-console"
+  gem "better_errors"
+  gem "binding_of_caller"
 end
 
 group :test do

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -96,8 +96,14 @@ GEM
       aws-eventstream (~> 1, >= 1.0.2)
     base64 (0.2.0)
     bcrypt (3.1.20)
+    better_errors (2.10.1)
+      erubi (>= 1.0.0)
+      rack (>= 0.9.0)
+      rouge (>= 1.0.0)
     bigdecimal (3.1.8)
     bindex (0.8.1)
+    binding_of_caller (1.0.1)
+      debug_inspector (>= 1.2.0)
     bootsnap (1.18.4)
       msgpack (~> 1.2)
     brakeman (7.0.0)
@@ -136,6 +142,7 @@ GEM
     debug (1.9.2)
       irb (~> 1.10)
       reline (>= 0.3.8)
+    debug_inspector (1.2.0)
     deep_merge (1.2.2)
     diff-lcs (1.5.1)
     docile (1.4.1)
@@ -361,6 +368,7 @@ GEM
     request_store (1.7.0)
       rack (>= 1.4)
     rexml (3.3.7)
+    rouge (4.5.1)
     rspec-core (3.13.2)
       rspec-support (~> 3.13.0)
     rspec-expectations (3.13.3)
@@ -484,6 +492,8 @@ PLATFORMS
 
 DEPENDENCIES
   aws-sdk-s3
+  better_errors
+  binding_of_caller
   bootsnap
   brakeman
   bullet

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -10,6 +10,7 @@ Rails.application.configure do
     Bullet.add_footer    = true
   end
 
+  BetterErrors::Middleware.allow_ip! "0.0.0.0/0"
   # Settings specified here will take precedence over those in config/application.rb.
   config.action_mailer.delivery_method = :letter_opener
   config.action_mailer.perform_deliveries = true


### PR DESCRIPTION
# 目的
ゆるふわLT会で一部の人から話題になってた「better_errors」を導入することにしてみた
https://zenn.dev/mochiblock/articles/89f8bf248b1bd8

# better_errorsとは
エラー画面が丁寧な説明に変わる
公式のGitHubによると
https://github.com/BetterErrors/better_errors

Railsの標準エラーページを、より優れた有用なエラーページに置き換える

# 対応方法
Gemfileにbulletを記述し、インストールする
binding_of_callerも一緒にセットでインストールするのが普通
````Ruby
group :development do
  gem "better_errors"
  gem "binding_of_caller"
end
````
````bash
docker compose run web bundle install
````
リモートアクセスの場合）どのIPからのアクセスを許可するか書く
Dockerを使用している場合も同様
config/environments/development.rbファイルに追記
````Ruby
  BetterErrors::Middleware.allow_ip! "0.0.0.0/0"
````