### PR TITLE
オートコンプリート検索機能実装

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -77,6 +77,10 @@ class PostsController < ApplicationController
       @user_posts = @q.result.page(params[:page]).per(9)
     end
 
+    def autocomplete
+     posts = Post.ransack(title_cont: params[:q]).result.limit(10)
+     render json: posts.pluck(:title)
+    end
 
     private
 

--- a/app/javascript/controllers/application.js
+++ b/app/javascript/controllers/application.js
@@ -1,9 +1,12 @@
 import { Application } from "@hotwired/stimulus"
+import { Autocomplete } from 'stimulus-autocomplete'
 
 const application = Application.start()
 
 // Configure Stimulus development experience
 application.debug = false
 window.Stimulus   = application
+
+application.register("autocomplete", Autocomplete)
 
 export { application }

--- a/app/views/posts/_search_form.html.erb
+++ b/app/views/posts/_search_form.html.erb
@@ -1,8 +1,9 @@
-<%= search_form_for @q, url: url do |f| %>
+<%= search_form_for @q, url: url, method: :get, html: { autocomplete: "off", data: { controller: "autocomplete" } } do |f| %>
     <div class="input-group mb-3">
-      <%= f.search_field :title_or_body_cont, class: 'form-control', placeholder: t('defaults.search_word') %>
+      <%= f.text_field :title_or_body_cont, class: "form-control", placeholder: t('posts.search_placeholder'), data: { autocomplete_target: "input", action: "input->autocomplete#search", autocomplete_url_value: autocomplete_posts_path } %>
       <div class="input-group-append">
         <%= f.submit class: 'btn btn-primary' %>
       </div>
     </div>
   <% end %>
+

--- a/app/views/posts/posts.html.erb
+++ b/app/views/posts/posts.html.erb
@@ -5,7 +5,6 @@
    </div>
  <div class="container pt-3">
     <div class="col-lg-10 offset-lg-1">
-      <!-- 検索フォームをここに追加 -->
       <%= render 'search_form', url: posts_posts_path, post_posts: @q %>
     </div>
   <div class="row">
@@ -13,8 +12,8 @@
       <div class="row">
        <% if @user_posts.present? %>
           <div class="row">
-          <%= render partial: 'posts/post', collection: @user_posts, as: :post %> <!-- 各投稿を表示する -->
-          <%= paginate @user_posts %> <!-- ページネーションの表示 -->
+          <%= render partial: 'posts/post', collection: @user_posts, as: :post %> 
+          <%= paginate @user_posts %> 
        <% else %>
           <p><%= t('.no_result') %></p>
        <% end %>

--- a/config/locales/view/ja.yml
+++ b/config/locales/view/ja.yml
@@ -2,7 +2,6 @@ ja:
   defaults:
     create: 作成
     post: 投稿
-    search_word: 検索ワード(タイトルまたは本文のキーワードから検索)
     delete_confirm: 削除しますか？
     flash_message:
       created: "%{item}を作成しました"
@@ -222,6 +221,7 @@ ja:
     posts:
       title: 投稿一覧
       no_result: 投稿がありません
+    search_placeholder: 検索ワード(タイトルまたは本文のキーワードから検索)
   profiles:
     show:
       title: プロフィール設定

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -41,6 +41,7 @@ Rails.application.routes.draw do
 
 
      collection do
+      get :autocomplete
       get :favorites
       get :posts
      end

--- a/package.json
+++ b/package.json
@@ -22,7 +22,8 @@
     "nodemon": "^3.1.4",
     "postcss": "^8.4.45",
     "postcss-cli": "^11.0.0",
-    "sass": "^1.78.0"
+    "sass": "^1.78.0",
+    "stimulus-autocomplete": "^3.1.0"
   },
   "browserslist": [
     "defaults"

--- a/yarn.lock
+++ b/yarn.lock
@@ -708,6 +708,11 @@ slash@^5.0.0, slash@^5.1.0:
   resolved "https://registry.yarnpkg.com/source-map-js/-/source-map-js-1.2.0.tgz#16b809c162517b5b8c3e7dcd315a2a5c2612b2af"
   integrity sha512-itJW8lvSA0TXEphiRoawsCksnlf8SyvmFzIhltqAHluXd88pkCd+cXJVHTDwdCr0IzwptSm035IHQktUu1QUMg==
 
+stimulus-autocomplete@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/stimulus-autocomplete/-/stimulus-autocomplete-3.1.0.tgz#7c9292706556ed0a87abf60ea2688bf0ea1176a8"
+  integrity sha512-SmVViCdA8yCl99oV2kzllNOqYjx7wruY+1OjAVsDTkZMNFZG5j+SqDKHMYbu+dRFy/SWq/PParzwZHvLAgH+YA==
+
 string-width@^4.1.0, string-width@^4.2.0, string-width@^4.2.3:
   version "4.2.3"
   resolved "https://registry.yarnpkg.com/string-width/-/string-width-4.2.3.tgz#269c7117d27b05ad2e536830a8ec895ef9c6d010"


### PR DESCRIPTION
# 概要
オートコンプリート検索機能を実装する

# 理由
1文字入力するたびに、候補が表示されるため、ユーザーの入力手間を減らし、入力ミスを減らすことができるため

# 参考資料
https://github.com/afcapel/stimulus-autocomplete

https://qiita.com/Yamamoto-Masaya1122/items/879d6eb540ce4e05cfe5

# 実装方法

## 1. stimulus-autocompleteをインストールする
文字を入力すると検索候補が表示される挙動を実現するために、stimulus-autocompleteを使う

js バンドラーnode_modules(esbuild、rollup.js、Webpack など) を使用している場合は、npm からパッケージをインストールする

※Rails7系ではrails newの段階でstimulus-railsが自動でインストールされているので、新たにStimulusをインストールしていない
````bash
yarn add stimulus-autocomplete

root@0be8e4763e50:/myapp# yarn add stimulus-autocomplete
yarn add v1.22.22
[1/4] Resolving packages...
[2/4] Fetching packages...
[3/4] Linking dependencies...
[4/4] Building fresh packages...
success Saved lockfile.
success Saved 1 new dependency.
info Direct dependencies
└─ stimulus-autocomplete@3.1.0
info All dependencies
└─ stimulus-autocomplete@3.1.0
Done in 51.36s.
````
app/javascript/controllers/application.jsにstimulus-autocompleteの設定を追加する
````JavaScript
import { Application } from "@hotwired/stimulus"
import { Autocomplete } from 'stimulus-autocomplete' #コンポーネントを読み込むための記述

const application = Application.start()

// Configure Stimulus development experience
application.debug = false
window.Stimulus   = application

application.register("autocomplete", Autocomplete) #コンポーネントにあるAutocompleteコントローラを使えるようにするための記述

export { application }
````
application.register('autocomplete', Autocomplete)の記述により、HTML内でdata-controller="autocomplete"の属性をもつ要素に対して、[Autocompleteコントローラ](https://github.com/afcapel/stimulus-autocomplete/blob/main/src/autocomplete.js)の機能が適用される

## 2. 検索フォームとオートコンプリート部分のビューを紐付ける
ルーティングを設定する
````Ruby
resources :posts, only: %i[index new create show edit destroy update] do
    resources :comments, only: %i[create destroy], shallow: true
    resource :favorites, only: [ :create, :destroy ]

     collection do
      get :autocomplete # 今回はPost側のモデルにオートコンプリート検索のルーティングを追加
      get :favorites
      get :posts
     end
  end
````
非同期のリクエストを受け取ってオートコンプリート部分のビューを返すためにpostsコントローラにautocompleteアクションを追加する
````Ruby
def autocomplete
     posts = Post.ransack(title_cont: params[:q]).result.limit(10) # Post(投稿)の検索においてtitleカラムにparams[:q]が含まれているか、最大10件までに制限
     render json: posts.pluck(:title) # 検索結果からtitleカラムのみを配列をJSON形式で返す
    end
````
フロントエンド（JavaScriptやstimulus-autocomplete）が、ユーザーの入力値をqというパラメータでサーバーに送信する
````bash
例: /posts/autocomplete?q=ジョージア
````
↓
Ransackで部分一致検索
````ruby
Post.ransack(title_cont: params[:q])
````
title_contは「titleカラムにparams[:q]が含まれているか」を意味する（cont = contains）。
````bash
例: [params[:q]](vscode-file://vscode-app/c:/Users/jiant/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)が「ジョージア」なら、「ジョージア」を含むタイトルのPostを検索する
````
````ruby
.result.limit(10)
````
Ransackの検索結果を取得し、最大10件までに制限する
オートコンプリート候補として多すぎない数を返すため
↓
````ruby
.pluck(:title)
````
検索結果からtitleカラムだけを配列で取り出す
例: ["ジョージア料理の魅力", "ジョージア旅行記", ...]
````ruby
render json: ...
````
配列をJSON形式で返す
フロントエンドのstimulus-autocompleteがこのJSON配列を受け取り、候補リストとして表示する

### まとめ
役割: 入力されたキーワードに部分一致するPostのタイトルを最大10件、JSON配列で返すAPIエンドポイント
用途: オートコンプリート（検索候補表示）用

## 3. 自動補完部分のビューを作る
````HTML
<%= search_form_for @q, url: url, method: :get, html: { autocomplete: "off", data: { controller: "autocomplete" } } do |f| %>
    <div class="input-group mb-3">
      <%= f.text_field :title_or_body_cont, class: "form-control", placeholder: t('posts.search_placeholder'), data: { autocomplete_target: "input", action: "input->autocomplete#search", autocomplete_url_value: autocomplete_posts_path } %>
      <div class="input-group-append">
        <%= f.submit class: 'btn btn-primary' %>
      </div>
    </div>
  <% end %>
````
入力フォームに文字を入力した時に、自動補完させたいので、検索フォーム(search_form)の中に
````HTML
method: :get, html: { autocomplete: "off", data: { controller: "autocomplete" } }
````
を追加する
Railsのフォームヘルパーとしては[text_field](vscode-file://vscode-app/c:/Users/jiant/AppData/Local/Programs/Microsoft%20VS%20Code/resources/app/out/vs/code/electron-sandbox/workbench/workbench.html)の方が一般的で、カスタマイズやCSS適用の面でも柔軟なことから、text_fieldに変更

Autocompleteコントローラが入力フォームを取得するために、
````HTML
data: { autocomplete_target: "input", action: "input->autocomplete#search", autocomplete_url_value: autocomplete_posts_path }
````
を追加する

````HTML
 data: { ... }
````
- Stimulus（stimulus-autocomplete）用の属性を設定する
````HTML
 autocomplete_target: "input"
````
- このinputがStimulusコントローラーのinputターゲットであることを示す
````HTML
action: "input->autocomplete#search"
````
- 入力時（inputイベント）にStimulusのautocomplete#searchアクションを呼び出す
````HTML
autocomplete_url_value: autocomplete_posts_path
````
- オートコンプリート候補を取得するAPIエンドポイントのURLを指定する

# 完成図
[![Image from Gyazo](https://i.gyazo.com/7915a54f79e6b54a685f46bd3e2f4d7b.gif)](https://gyazo.com/7915a54f79e6b54a685f46bd3e2f4d7b)

[![Image from Gyazo](https://i.gyazo.com/8e83ced9c89b3f24ecf5f383c7a5ba84.gif)](https://gyazo.com/8e83ced9c89b3f24ecf5f383c7a5ba84)

[![Image from Gyazo](https://i.gyazo.com/fce8ae6971894a232a09a5af7142a53b.gif)](https://gyazo.com/fce8ae6971894a232a09a5af7142a53b)